### PR TITLE
Hydra: Spike to evaluate musig2 signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 libmusig2.o
 musig2test
 musig2test.dSYM/
+
+# musgi2test artifacts
+/aggregate.pub

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ musig2test
 musig2test.dSYM/
 
 # musgi2test artifacts
-/aggregate.pub
-/valid.signed
+/*.pub
+/*.signed

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ musig2test.dSYM/
 
 # musgi2test artifacts
 /aggregate.pub
+/valid.signed

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ make
 ./musig2test
 ```
 
+## Build in nix-shell
+
+The provided `shell.nix` provides build tools and the right version of
+`libsodium`, so simply using `nix-shell` and `make` is sufficient to build.
+
 # Disclaimer
 This code is work in progress, and has not been audited. Do not use in production. 
 

--- a/VerifySignature.hs
+++ b/VerifySignature.hs
@@ -15,6 +15,8 @@ main :: IO ()
 main = do
   pubKey <- throwCryptoErrorIO . publicKey =<< BS.readFile "aggregate.pub"
   verifySignature pubKey "valid.signed"
+  verifySignature pubKey "valid2.signed"
+  verifySignature pubKey "invalid.signed"
 
 verifySignature :: PublicKey -> String -> IO ()
 verifySignature pubKey fn = do

--- a/VerifySignature.hs
+++ b/VerifySignature.hs
@@ -1,0 +1,28 @@
+#!/usr/bin/env cabal
+
+{- cabal:
+build-depends: base
+             , bytestring
+             , cardano-crypto
+             , cryptonite
+-}
+
+import Crypto.ECC.Ed25519Donna (PublicKey, publicKey, signature, verify)
+import Crypto.Error (throwCryptoErrorIO)
+import qualified Data.ByteString as BS
+
+main :: IO ()
+main = do
+  pubKey <- throwCryptoErrorIO . publicKey =<< BS.readFile "aggregate.pub"
+  verifySignature pubKey "valid.signed"
+
+verifySignature :: PublicKey -> String -> IO ()
+verifySignature pubKey fn = do
+  sm <- BS.readFile fn
+  let (sig, msg) = BS.splitAt 64 sm
+  sig' <- throwCryptoErrorIO $ signature sig
+  let result =
+        if verify pubKey msg sig'
+          then "✓ Valid"
+          else "✘ Invalid"
+  putStrLn $ fn <> " " <> show msg <> " " <> result

--- a/VerifySignature.hs
+++ b/VerifySignature.hs
@@ -13,7 +13,9 @@ import qualified Data.ByteString as BS
 
 main :: IO ()
 main = do
+  putStrLn "Loading public key: aggregate.pub"
   pubKey <- throwCryptoErrorIO . publicKey =<< BS.readFile "aggregate.pub"
+  putStrLn ""
   verifySignature pubKey "valid.signed"
   verifySignature pubKey "valid2.signed"
   verifySignature pubKey "invalid.signed"

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-crypto.git
+  tag: 07397f0e50da97eaa0575d93bee7ac4b2b2576ec

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,8 @@
+indentation: 2
+comma-style: leading # for lists, tuples etc. - can also be 'trailing'
+record-brace-space: false # rec {x = 1} vs. rec{x = 1}
+indent-wheres: false # 'false' means save space by only half-indenting the 'where' keyword
+diff-friendly-import-export: true # 'false' uses Ormolu-style lists
+respectful: true # don't be too opinionated about newlines etc.
+haddock-style: single-line # '--' vs. '{-'
+newlines-between-decls: 1 # number of newlines between top-level declarations

--- a/libsodium.nix
+++ b/libsodium.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.libsodium.overrideAttrs (oldAttrs: {
+    name = "libsodium-1.0.18-musig2";
+    src = pkgs.fetchFromGitHub {
+      owner = "input-output-hk";
+      repo = "libsodium";
+      # branch musig2_compat
+      rev = "7f9f211fcc88d8f0d7a821e5b9041268c392300a";
+      sha256 = "0527x23z1h4ny492jjmyxpwb48hrlbgibin83w1qm0jqvg441xgp";
+    };
+    nativeBuildInputs = [ pkgs.autoreconfHook ];
+    configureFlags = "--enable-static";
+  })

--- a/musig2test.c
+++ b/musig2test.c
@@ -125,6 +125,14 @@ int main(int argc, char **argv) {
   prepare_final_signature(sm, part_sigs, aggr_announcement, MESSAGE,
                           MESSAGE_LEN, NR_SIGNERS);
 
+  // Dump correcly signed message for testing verification within Haskell
+  const char *fn_sm = "valid.signed";
+  if (writeBytes(fn_sm, sm, 64 + MESSAGE_LEN) != 0) {
+    perror("Failed writing signed message");
+    return EXIT_FAILURE;
+  }
+  printf("Written signed message to: %s\n", fn_sm);
+
   // Now, the verification using the standard libsodium's verification equation
   // will work.
   unsigned char unsigned_message[MESSAGE_LEN];

--- a/musig2test.c
+++ b/musig2test.c
@@ -11,8 +11,8 @@ int writeBytes(const char *fn, unsigned char *bytes, size_t count) {
     return EXIT_FAILURE;
   }
   unsigned int written = fwrite(bytes, sizeof(unsigned char), count, fp);
-  if (written != crypto_core_ed25519_BYTES) {
-    printf("not all bytes written to %s", fn);
+  if (written != count) {
+    printf("Not all bytes written to %s", fn);
     return EXIT_FAILURE;
   }
   return fclose(fp);
@@ -170,6 +170,14 @@ int main(int argc, char **argv) {
   prepare_final_signature(sm_2, part_sigs_2, aggr_announcement_2, MESSAGE_2,
                           MESSAGE_2_LEN, NR_SIGNERS);
 
+  // Dump another correcly signed message for testing verification within Haskell
+  const char *fn_sm_2 = "valid2.signed";
+  if (writeBytes(fn_sm_2, sm_2, 64 + MESSAGE_2_LEN) != 0) {
+    perror("Failed writing signed message");
+    return EXIT_FAILURE;
+  }
+  printf("Written signed message to: %s\n", fn_sm_2);
+
   // VERIFICATION //
   unsigned char unsigned_message_2[MESSAGE_2_LEN];
   unsigned long long unsigned_message_len_2;
@@ -193,4 +201,13 @@ int main(int argc, char **argv) {
                        64 + MESSAGE_LEN, pk_ed25519) == 0) {
     printf("This should not validate\n");
   }
+
+
+  // Dump invalid signed message for testing verification within Haskell
+  const char *fn_invalid_sm = "invalid.signed";
+  if (writeBytes(fn_invalid_sm, invalid_sm, 64 + MESSAGE_LEN) != 0) {
+    perror("Failed writing signed message");
+    return EXIT_FAILURE;
+  }
+  printf("Written signed message to: %s\n", fn_invalid_sm);
 }

--- a/musig2test.c
+++ b/musig2test.c
@@ -1,154 +1,168 @@
 #include "libmusig2.h"
 #include "stdio.h"
 
+#include <assert.h>
 #include <sodium.h>
 #include <string.h>
-#include <assert.h>
 
 int main(int argc, char **argv) {
-    // Number of signers
-    const int NR_SIGNERS = 5;
+  // Number of signers
+  const int NR_SIGNERS = 5;
 
-    // We provide an example with two messages, where parties precompute the nonces.
-    // In the precomputation scenario, it is very important
-    // that they keep state of what are the rand_nonces that they have used, otherwise
-    // their keys will be vulnerable.
-    const int NR_MESSAGES = 2;
-    int STATE = 0;
-    #define MESSAGE (const unsigned char *) "test"
-    #define MESSAGE_LEN 4
+  // We provide an example with two messages, where parties precompute the
+  // nonces. In the precomputation scenario, it is very important that they keep
+  // state of what are the rand_nonces that they have used, otherwise their keys
+  // will be vulnerable.
+  const int NR_MESSAGES = 2;
+  int STATE = 0;
+#define MESSAGE (const unsigned char *)"test"
+#define MESSAGE_LEN 4
 
-    #define MESSAGE_2 (const unsigned char *) "testcallrustsign"
-    #define MESSAGE_2_LEN 16
+#define MESSAGE_2 (const unsigned char *)"testcallrustsign"
+#define MESSAGE_2_LEN 16
 
-    // Parties generate their key-pairs
-    unsigned char pks[NR_SIGNERS * crypto_core_ristretto255_BYTES];
-    unsigned char sks[NR_SIGNERS * crypto_core_ristretto255_SCALARBYTES];
+  // Parties generate their key-pairs
+  unsigned char pks[NR_SIGNERS * crypto_core_ristretto255_BYTES];
+  unsigned char sks[NR_SIGNERS * crypto_core_ristretto255_SCALARBYTES];
 
-    for (int i = 0; i < NR_SIGNERS; i++) {
-        keypair_gen(sks + i * crypto_core_ristretto255_SCALARBYTES, pks + i * crypto_core_ristretto255_BYTES);
-    }
+  for (int i = 0; i < NR_SIGNERS; i++) {
+    keypair_gen(sks + i * crypto_core_ristretto255_SCALARBYTES,
+                pks + i * crypto_core_ristretto255_BYTES);
+  }
 
-    // Now that we know all the parties public keys, we can compute the (public) exponent
-    // of each party, and the aggregated public key.
-    unsigned char aggr_pk[crypto_core_ristretto255_BYTES];
-    if (aggregate_pks(aggr_pk, pks, NR_SIGNERS) == -1) {
-        printf("some party misbehaved, and incorrectly generated their keys.");
-    }
+  // Now that we know all the parties public keys, we can compute the (public)
+  // exponent of each party, and the aggregated public key.
+  unsigned char aggr_pk[crypto_core_ristretto255_BYTES];
+  if (aggregate_pks(aggr_pk, pks, NR_SIGNERS) == -1) {
+    printf("some party misbehaved, and incorrectly generated their keys.");
+  }
 
-    // We can also prepare the ed25519 representative of the public key (the one that will be used by
-    // the ed25519 verifier).
-    unsigned char pk_ed25519[crypto_core_ed25519_BYTES];
-    if (map_ristretto_prime_subgroup(pk_ed25519, aggr_pk) == -1) {
-        // we've checked above that all public keys are valid. If that is the case, then this check will
-        // never fail.
-        printf("aggregated pk is not a valid ristretto point");
-    }
+  // We can also prepare the ed25519 representative of the public key (the one
+  // that will be used by the ed25519 verifier).
+  unsigned char pk_ed25519[crypto_core_ed25519_BYTES];
+  if (map_ristretto_prime_subgroup(pk_ed25519, aggr_pk) == -1) {
+    // we've checked above that all public keys are valid. If that is the case,
+    // then this check will never fail.
+    printf("aggregated pk is not a valid ristretto point");
+  }
 
-    unsigned char public_exponents[NR_SIGNERS * crypto_core_ristretto255_SCALARBYTES];
-    for (int i = 0; i < NR_SIGNERS; i++) {
-        compute_exponent(public_exponents + i * crypto_core_ristretto255_SCALARBYTES, pks, i, NR_SIGNERS);
-    }
+  unsigned char
+      public_exponents[NR_SIGNERS * crypto_core_ristretto255_SCALARBYTES];
+  for (int i = 0; i < NR_SIGNERS; i++) {
+    compute_exponent(public_exponents +
+                         i * crypto_core_ristretto255_SCALARBYTES,
+                     pks, i, NR_SIGNERS);
+  }
 
-    // Now each party generates their batched randomness---note that here signers do not
-    // need to know the pks of other participants nor the message. Once they precompute all
-    // randomness, they send the commitment over the broadcast channel. The nonces themselves
-    // MUST NOT be sent to other parties.
-    unsigned char rand_comm[NR_MESSAGES * NR_SIGNERS * NR_V * crypto_core_ristretto255_BYTES];
-    unsigned char rand_nonc[NR_MESSAGES * NR_SIGNERS * NR_V * crypto_core_ristretto255_SCALARBYTES];
+  // Now each party generates their batched randomness---note that here signers
+  // do not need to know the pks of other participants nor the message. Once
+  // they precompute all randomness, they send the commitment over the broadcast
+  // channel. The nonces themselves MUST NOT be sent to other parties.
+  unsigned char rand_comm[NR_MESSAGES * NR_SIGNERS * NR_V *
+                          crypto_core_ristretto255_BYTES];
+  unsigned char rand_nonc[NR_MESSAGES * NR_SIGNERS * NR_V *
+                          crypto_core_ristretto255_SCALARBYTES];
 
-    for (int i = 0; i < NR_SIGNERS; i++) {
-        batch_commit(rand_comm + i * NR_MESSAGES * NR_V * crypto_core_ristretto255_BYTES,
-               rand_nonc + i * NR_MESSAGES * NR_V * crypto_core_ristretto255_SCALARBYTES,
-               NR_MESSAGES);
-    }
+  for (int i = 0; i < NR_SIGNERS; i++) {
+    batch_commit(rand_comm +
+                     i * NR_MESSAGES * NR_V * crypto_core_ristretto255_BYTES,
+                 rand_nonc + i * NR_MESSAGES * NR_V *
+                                 crypto_core_ristretto255_SCALARBYTES,
+                 NR_MESSAGES);
+  }
 
-    // Now parties generate their partial signature for message 1. They broadcast their
-    // partial signature to the other participants. Alternatively, this can be sent
-    // to a single aggregator, or to the verifier.
-    unsigned char part_sigs[NR_SIGNERS * crypto_core_ristretto255_SCALARBYTES];
-    // The aggr_announcement is the same for all signers, hence we only need one variable.
-    unsigned char aggr_announcement[crypto_core_ristretto255_BYTES];
+  // Now parties generate their partial signature for message 1. They broadcast
+  // their partial signature to the other participants. Alternatively, this can
+  // be sent to a single aggregator, or to the verifier.
+  unsigned char part_sigs[NR_SIGNERS * crypto_core_ristretto255_SCALARBYTES];
+  // The aggr_announcement is the same for all signers, hence we only need one
+  // variable.
+  unsigned char aggr_announcement[crypto_core_ristretto255_BYTES];
 
-    for (int i = 0; i < NR_SIGNERS; i++) {
-        partial_signature(part_sigs + i * crypto_core_ristretto255_SCALARBYTES,
-                          aggr_announcement,
-                          aggr_pk,
-                          sks + i * crypto_core_ristretto255_SCALARBYTES,
-                          rand_nonc + STATE * NR_SIGNERS * NR_V * crypto_core_ristretto255_SCALARBYTES + i * NR_V * crypto_core_ristretto255_SCALARBYTES,
-                          rand_comm + STATE * NR_SIGNERS * NR_V * crypto_core_ristretto255_BYTES,
-                          public_exponents + i * crypto_core_ristretto255_SCALARBYTES,
-                          MESSAGE,
-                          MESSAGE_LEN,
-                          NR_SIGNERS);
-    }
+  for (int i = 0; i < NR_SIGNERS; i++) {
+    partial_signature(
+        part_sigs + i * crypto_core_ristretto255_SCALARBYTES, aggr_announcement,
+        aggr_pk, sks + i * crypto_core_ristretto255_SCALARBYTES,
+        rand_nonc +
+            STATE * NR_SIGNERS * NR_V * crypto_core_ristretto255_SCALARBYTES +
+            i * NR_V * crypto_core_ristretto255_SCALARBYTES,
+        rand_comm + STATE * NR_SIGNERS * NR_V * crypto_core_ristretto255_BYTES,
+        public_exponents + i * crypto_core_ristretto255_SCALARBYTES, MESSAGE,
+        MESSAGE_LEN, NR_SIGNERS);
+  }
 
-    // At each signature, the state needs to be updated
-    STATE = 1;
+  // At each signature, the state needs to be updated
+  STATE = 1;
 
-    // As a safety measure, the nonce used should be safely deleted. This could be done by overwriting random
-    // bytes. Overwriting zeroes should only be done if before signing the nodes check that the nonces are
-    // not zero. Otherwise, using a nonce full of zeros is a security vulnerability.
+  // As a safety measure, the nonce used should be safely deleted. This could be
+  // done by overwriting random bytes. Overwriting zeroes should only be done if
+  // before signing the nodes check that the nonces are not zero. Otherwise,
+  // using a nonce full of zeros is a security vulnerability.
 
-    // And finally, the different parties (or the aggregator) aggregate the different signatures, and prepare
-    // them to be ed25519 compatible.
-    unsigned char sm[64 + MESSAGE_LEN];
-    prepare_final_signature(sm,part_sigs,aggr_announcement, MESSAGE, MESSAGE_LEN, NR_SIGNERS);
+  // And finally, the different parties (or the aggregator) aggregate the
+  // different signatures, and prepare them to be ed25519 compatible.
+  unsigned char sm[64 + MESSAGE_LEN];
+  prepare_final_signature(sm, part_sigs, aggr_announcement, MESSAGE,
+                          MESSAGE_LEN, NR_SIGNERS);
 
-    // Now, the verification using the standard libsodium's verification equation will work.
-    unsigned char unsigned_message[MESSAGE_LEN];
-    unsigned long long unsigned_message_len;
+  // Now, the verification using the standard libsodium's verification equation
+  // will work.
+  unsigned char unsigned_message[MESSAGE_LEN];
+  unsigned long long unsigned_message_len;
 
-    printf("First verification: ");
-    if (crypto_sign_open(unsigned_message, &unsigned_message_len, sm, 64 + MESSAGE_LEN, pk_ed25519) != 0) {
-        printf("Translated signature failed\n");
-        return -1;
-    }
-    else {
-        printf("Translated signature worked!\n");
-    }
+  printf("First verification: ");
+  if (crypto_sign_open(unsigned_message, &unsigned_message_len, sm,
+                       64 + MESSAGE_LEN, pk_ed25519) != 0) {
+    printf("Translated signature failed\n");
+    return -1;
+  } else {
+    printf("Translated signature worked!\n");
+  }
 
-    // Second message //
-    // Now that we have precomputed the nonces, we can directly compute the signature
-    unsigned char part_sigs_2[NR_SIGNERS * crypto_core_ristretto255_SCALARBYTES];
-    unsigned char aggr_announcement_2[crypto_core_ristretto255_BYTES];
+  // Second message //
+  // Now that we have precomputed the nonces, we can directly compute the
+  // signature
+  unsigned char part_sigs_2[NR_SIGNERS * crypto_core_ristretto255_SCALARBYTES];
+  unsigned char aggr_announcement_2[crypto_core_ristretto255_BYTES];
 
-    for (int i = 0; i < NR_SIGNERS; i++) {
-        partial_signature(part_sigs_2 + i * crypto_core_ristretto255_SCALARBYTES,
-                          aggr_announcement_2,
-                          aggr_pk,
-                          sks + i * crypto_core_ristretto255_SCALARBYTES,
-                          rand_nonc + STATE * NR_V * crypto_core_ristretto255_SCALARBYTES + i * NR_V * crypto_core_ristretto255_SCALARBYTES,
-                          rand_comm + STATE * NR_V * crypto_core_ristretto255_BYTES,
-                          public_exponents + i * crypto_core_ristretto255_SCALARBYTES,
-                          MESSAGE_2,
-                          MESSAGE_2_LEN,
-                          NR_SIGNERS);
-    }
+  for (int i = 0; i < NR_SIGNERS; i++) {
+    partial_signature(
+        part_sigs_2 + i * crypto_core_ristretto255_SCALARBYTES,
+        aggr_announcement_2, aggr_pk,
+        sks + i * crypto_core_ristretto255_SCALARBYTES,
+        rand_nonc + STATE * NR_V * crypto_core_ristretto255_SCALARBYTES +
+            i * NR_V * crypto_core_ristretto255_SCALARBYTES,
+        rand_comm + STATE * NR_V * crypto_core_ristretto255_BYTES,
+        public_exponents + i * crypto_core_ristretto255_SCALARBYTES, MESSAGE_2,
+        MESSAGE_2_LEN, NR_SIGNERS);
+  }
 
-    // And finally, we aggregate the different signatures
-    unsigned char sm_2[64 + MESSAGE_2_LEN];
-    prepare_final_signature(sm_2,part_sigs_2,aggr_announcement_2, MESSAGE_2, MESSAGE_2_LEN, NR_SIGNERS);
+  // And finally, we aggregate the different signatures
+  unsigned char sm_2[64 + MESSAGE_2_LEN];
+  prepare_final_signature(sm_2, part_sigs_2, aggr_announcement_2, MESSAGE_2,
+                          MESSAGE_2_LEN, NR_SIGNERS);
 
-    // VERIFICATION //
-    unsigned char unsigned_message_2[MESSAGE_2_LEN];
-    unsigned long long unsigned_message_len_2;
+  // VERIFICATION //
+  unsigned char unsigned_message_2[MESSAGE_2_LEN];
+  unsigned long long unsigned_message_len_2;
 
-    printf("Second verification: ");
-    // now we check the signature! We use the same aggregate public key as before.
-    if (crypto_sign_open(unsigned_message_2, &unsigned_message_len_2, sm_2, 64 + MESSAGE_2_LEN, pk_ed25519) != 0) {
-        printf("Translated signature failed\n");
-        return -1;
-    }
-    else {
-        printf("Translated signature worked!\n");
-    }
+  printf("Second verification: ");
+  // now we check the signature! We use the same aggregate public key as before.
+  if (crypto_sign_open(unsigned_message_2, &unsigned_message_len_2, sm_2,
+                       64 + MESSAGE_2_LEN, pk_ed25519) != 0) {
+    printf("Translated signature failed\n");
+    return -1;
+  } else {
+    printf("Translated signature worked!\n");
+  }
 
-    // finally, we simply ensure that the verification function does not always output true. We try to verify
-    // the second signature with the first message.
-    unsigned char invalid_sm[64 + MESSAGE_LEN];
-    prepare_final_signature(invalid_sm, part_sigs_2, aggr_announcement_2, MESSAGE, MESSAGE_LEN, NR_SIGNERS);
-    if (crypto_sign_open(unsigned_message_2, &unsigned_message_len_2, invalid_sm, 64 + MESSAGE_LEN, pk_ed25519) == 0) {
-        printf("This should not validate\n");
-    }
+  // finally, we simply ensure that the verification function does not always
+  // output true. We try to verify the second signature with the first message.
+  unsigned char invalid_sm[64 + MESSAGE_LEN];
+  prepare_final_signature(invalid_sm, part_sigs_2, aggr_announcement_2, MESSAGE,
+                          MESSAGE_LEN, NR_SIGNERS);
+  if (crypto_sign_open(unsigned_message_2, &unsigned_message_len_2, invalid_sm,
+                       64 + MESSAGE_LEN, pk_ed25519) == 0) {
+    printf("This should not validate\n");
+  }
 }

--- a/musig2test.c
+++ b/musig2test.c
@@ -10,8 +10,8 @@ int writeBytes(const char *fn, unsigned char *bytes, size_t count) {
   if (!fp) {
     return EXIT_FAILURE;
   }
-  if (fwrite(bytes, sizeof(unsigned char), crypto_core_ed25519_BYTES, fp) !=
-      crypto_core_ed25519_BYTES) {
+  unsigned int written = fwrite(bytes, sizeof(unsigned char), count, fp);
+  if (written != crypto_core_ed25519_BYTES) {
     printf("not all bytes written to %s", fn);
     return EXIT_FAILURE;
   }

--- a/musig2test.c
+++ b/musig2test.c
@@ -5,6 +5,19 @@
 #include <sodium.h>
 #include <string.h>
 
+int writeBytes(const char *fn, unsigned char *bytes, size_t count) {
+  FILE *fp = fopen(fn, "w+");
+  if (!fp) {
+    return EXIT_FAILURE;
+  }
+  if (fwrite(bytes, sizeof(unsigned char), crypto_core_ed25519_BYTES, fp) !=
+      crypto_core_ed25519_BYTES) {
+    printf("not all bytes written to %s", fn);
+    return EXIT_FAILURE;
+  }
+  return fclose(fp);
+}
+
 int main(int argc, char **argv) {
   // Number of signers
   const int NR_SIGNERS = 5;
@@ -45,6 +58,13 @@ int main(int argc, char **argv) {
     // then this check will never fail.
     printf("aggregated pk is not a valid ristretto point");
   }
+  // Dump the ed25519 pubkey for testing verification within Haskell
+  const char *fn_ed25519 = "aggregate.pub";
+  if (writeBytes(fn_ed25519, pk_ed25519, crypto_core_ed25519_BYTES) != 0) {
+    perror("Failed writing Ed25519 key");
+    return EXIT_FAILURE;
+  }
+  printf("Written aggregate ed25519 key to: %s\n", fn_ed25519);
 
   unsigned char
       public_exponents[NR_SIGNERS * crypto_core_ristretto255_SCALARBYTES];

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {}
+, libsodium-musig2 ? import ./libsodium.nix { inherit pkgs; }
+}:
+
+pkgs.mkShell {
+  buildInputs = [pkgs.clang libsodium-musig2];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,14 @@
-{ pkgs ? import <nixpkgs> {}
+{ pkgs ? import <nixpkgs> { }
 , libsodium-musig2 ? import ./libsodium.nix { inherit pkgs; }
 }:
 
 pkgs.mkShell {
-  buildInputs = [pkgs.clang libsodium-musig2];
+  buildInputs = [
+    # build musig2test
+    pkgs.clang
+    libsodium-musig2
+    # verify signature haskell script
+    pkgs.cabal-install
+    pkgs.ghc
+  ];
 }


### PR DESCRIPTION
Draft PR (no intention to merge for now) covering a quick spike we had to investigate whether the produced signatures are verifiable by [cardano-crypto](https://github.com/input-output-hk/cardano-crypto/blob/develop/src/Crypto/ECC/Ed25519Donna.hs). Seemingly that implementation of Ed25519 is used in `Plutus.Builtins` and thus by the Plutus interpreter.

CC @abailly-iohk @KtorZ

![image](https://user-images.githubusercontent.com/2621189/135490774-000fb7a2-ec4d-4951-8d7b-0331bc14ac4b.png)
