### PR TITLE
readme updated for libsecp compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ However, the aggregation of public keys and the commitments may not result point
 Therefore, signers do the following in the single signature generation step:
 
 
-- **Case 1** ($X$ has odd, $R$ has even `Y` coordinate): In this case, signers negate $c$. 
+- **Case 1** ( $X$ has odd, $R$ has even `Y` coordinate): In this case, signers negate $c$. 
 Negating $c$ is equivalent to negating $X$, since
 
 $$ G \cdot s = R + (-X) \cdot (-c) $$
 
-- **Case 2** ($X$ has even, $R$ has odd `Y` coordinate): In this case, 
+- **Case 2** ( $X$ has even, $R$ has odd `Y` coordinate): In this case, 
 signers negate every element in the list $b^0, b^1, \ldots, b^{V-1}$, so $R$ is also negated.
 
 - **Case 3** (Both have odd `Y` coordinates): Signers negates their partial signature, so that the aggregated signature will be negated:
@@ -95,8 +95,12 @@ $$ G \cdot (-s) = (-R) + (-X) \cdot c. $$
 
 ### AOMDL
 The security of MuSig2 depends on the hardness of *algebraic one more discrete logarithm (AOMDL)* problem. 
-In the standard one more discrete logarithm problem, an adversary is given the public parameters ($E(F_p), G, p$) and wins if it can solve the discrete logarithms ($x_1, \ldots, x_{q+1}$) of $q+1$ challenge group elements ($X_1, \ldots, X_{q+1}$) by only making at most $q$ queries to $D_{LOG}$ oracle.
-The algebraic version of this problem requires to include an algebraic representation $(\alpha, (\beta_i)_{1 \leq i \leq c})$ of the challenge $X$ such $X = G \cdot \alpha + \Sigma_{i=1}^{c}(X_i \cdot \beta_i)$.
+In the standard one more discrete logarithm problem, an adversary is given the public parameters $(E(F_p), G, p)$ and wins if it can solve the discrete logarithms $(x_1, \ldots, x_{q+1})$ of $q+1$ challenge group elements $(X_1, \ldots, X_{q+1})$ by only making at most $q$ queries to $D_{LOG}$ oracle.
+The algebraic version of this problem requires to include an algebraic representation $(\alpha, (\beta_i)_{1 \leq i \leq c})$ 
+of the challenge $X$ such that:
+
+$$ X = G \cdot \alpha + \Sigma_{i = 1}^{c}(X_i \cdot \beta_i). $$
+
 The question is that whether using xonly encoding for the public keys reduce the security of the scheme.
 If there exists a polynomial algorithm to solve AOMDL for xonly encoding of a curve point, then it basically implies that AOMDL is broken for full-size encoding as well, since every `X` coordinate has two possible `Y` coordinate as odd or even. 
 

--- a/README.md
+++ b/README.md
@@ -49,27 +49,69 @@ Instead of encoding full `X`, `Y` coordinates of $R$ and $X$ (64-byte public key
 - **Implicit `Y` coordinate:**
 Schnorr signatures of BIP-430 implicitly choose the `Y` coordinate that is even.
 
-- **Tagged hashes:**
-In order to prevent the collisions and reuse of nonce, it is preferred to include the tag by prefixing the hash data with `SHA256(tag) || SHA256(tag)`.
-
 ### Security considerations
 
 The xonly encoding of elliptic curve points causes ambiguity since every `X` coordinate has two possible `Y` coordinates. 
 To avoid this ambiguity they chose to select elliptic curve points with even `Y` coordinates.
-The xonly encoding of a point prefixed by the byte `0x02` is equivalent to representing it with a 33-byte but more compact. 
-Moreover, this encoding does not reduce the security of the system. 
+The xonly encoding of a point is equivalent to representing it with a 33-byte but more compact since only the points with even `Y` coordinate are preferred there is no need to use one extra byte to specify the sign of the point. 
+Moreover, this encoding does not reduce the security of the system (see [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#:~:text=Despite%20halving%20the,8%5D.)). 
 Even if there is an algorithm to solve ECDLP for the xonly encoding, then the full encoding will also be automatically broken since the `X` coordinate has two possible `Y` coordinates as negative and positive.
 
 ## Adapting MuSig2 to PIB-430
 
 [MuSig2](https://eprint.iacr.org/2020/1261.pdf) 
-is a two-round multi-signature scheme that outputs an ordinary Schnorr signature.
+is a two-round multi-signature scheme that outputs an ordinary Schnorr signature. 
 
-$$ G \cdot s = R + X \cdot c. $$
+1. **Setup:** Let $p$ be a prime and $E$ be an elliptic curve defined over the finite field $F_p$ with the base point $G$ of order $p$.
+
+2. **Key generation:** Every signer selects $x_i$ randomly in $\bmod p$ as secret key, and corresponding public key is $X_i = x_i \cdot G$.
+
+3. **Batch commitment:** Signers create a list of batch commitments including $V$ elements.
+   The commitment of a signer is an elliptic curve point such that $R = r \cdot G$ where $r$ is randomly selected in $\bmod p$. Then, the batch commitments of the system are
+
+$$ {R_{11}, R_{12}, \ldots, R_{1V},\ldots, R_{N1}, \ldots, R_{NV}} $$
+
+where $N$ is the number of signers, and $V$ is the number of nonces.
+
+4. **Aggregate public key:** After receiving the public keys of the registered signers, each signer aggregate the public key as follows:
+
+$$ L = (X_1 || X_2 || \ldots || X_N) $$
+
+$$ a_i = H_{agg}(L || X_i)_{i = 1..N} $$
+
+$$ X = \Sigma_{i = 1}^{N} (a_i \cdot X_i) $$
+
+Finally, the signer obtains the public key $X$ and keeps her own $a_i$.
+
+5. **Aggregate commitments:** After receiving the batch commitment list, a signer computes the aggregate nonce as follows:
+
+$$ R_i = (R_{i1}, \ldots, R_{iV})_{i = 1..N} $$
+
+$$ R_j = (\Sigma_{i = 1}^{V} (R_{ij})_{i = 1..N}) $$
+
+6. **Single signature:** A single signature $s_i$ is generated as:
+
+$$ b = H_{non}(X || (R_1 || \ldots || R_V) || m) $$
+
+$$ R = \Sigma_{i = 1}^{V}(R_j^{b^{j-1}}) $$
+
+$$ c = H_{sig}(X || R || m) $$
+
+$$ s_i = c  a_i x_i + \Sigma_{i = 1}^{V}(r_{ij}   b^{j-1})$$
+
+7. **Aggregate signature:** The aggregate signature $s$ is:
+
+$$ s = \Sigma_{i = 1}^{N}(s_i) $$
+
+So, the MuSig2 is $(R, s)$.
+
+8. **Verification:** The verifier computes $c = H_{sig}(X || R || m)$ and accepts the signature if $s \cdot G = R + c \cdot X$.
+
+$$ s \cdot G = R + c \cdot X. $$
 
 The aggregated public key $X$ is generated with the public keys of all signers:
 
-$$ X = \Sigma_{i = 1}^{N} (X_i \cdot a_i) $$
+$$ X = \Sigma_{i = 1}^{N} (a_i \cdot X_i) $$
 
 where $a_i$ is the key aggregate coefficient.
 The commitment $R$ is also generated with the commitments of signers and the nonce $b$.
@@ -84,14 +126,14 @@ Therefore, signers do the following in the single signature generation step:
 - **Case 1** ( $X$ has odd, $R$ has even `Y` coordinate): In this case, signers negate $c$. 
 Negating $c$ is equivalent to negating $X$, since
 
-$$ G \cdot s = R + (-X) \cdot (-c) $$
+$$ s \cdot G = R + (-c) \cdot (-X) $$
 
 - **Case 2** ( $X$ has even, $R$ has odd `Y` coordinate): In this case, 
 signers negate every element in the list $b^0, b^1, \ldots, b^{V-1}$, so $R$ is also negated.
 
 - **Case 3** (Both have odd `Y` coordinates): Signers negates their partial signature, so that the aggregated signature will be negated:
 
-$$ G \cdot (-s) = (-R) + (-X) \cdot c. $$
+$$ (-s) \cdot G = (-R) + c \cdot (-X). $$
 
 ### AOMDL
 The security of MuSig2 depends on the hardness of *algebraic one more discrete logarithm (AOMDL)* problem. 
@@ -99,7 +141,7 @@ In the standard one more discrete logarithm problem, an adversary is given the p
 The algebraic version of this problem requires to include an algebraic representation $(\alpha, (\beta_i)_{1 \leq i \leq c})$ 
 of the challenge $X$ such that:
 
-$$ X = G \cdot \alpha + \Sigma_{i = 1}^{c}(X_i \cdot \beta_i). $$
+$$ X = \alpha \cdot G  + \Sigma_{i = 1}^{c}(\beta_i \cdot X_i). $$
 
 The question is that whether using xonly encoding for the public keys reduce the security of the scheme.
 If there exists a polynomial algorithm to solve AOMDL for xonly encoding of a curve point, then it basically implies that AOMDL is broken for full-size encoding as well, since every `X` coordinate has two possible `Y` coordinate as odd or even. 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,29 @@ This implementation requires configuring the libsecp256k1 with an additional fla
 
 Run the example with examplemusig2.c
 
-```
+```shell
 make ctest
 ./ctest_run/ctest
 ```
 
 Run the Google tests with
 
-```
+```shell
 make gtest
 ./gtest_run/gtest
+```
+
+Running Valgrind in MacOs can be quite painful. 
+We included a Dockerfile to run valgrind checks on MacOs with an arm chip (e.g. M1).
+To test the code with valgrind, run the following:
+```shell
+ docker build -t "valgrind:1.0" .
+ docker run -it -v $PWD:/tmp -w /tmp valgrind:1.0
+```
+
+and once you are interacting with the container, run
+```shell
+make valgrind
 ```
 
 ## Schnorr Signature of libsecp256k1
@@ -27,28 +40,16 @@ The library offers an optional module implementing Schnorr signatures over the c
 The scheme is compatible with [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) that produces 64-byte Schnorr signatures. 
 BIP-340 standardized the scheme with some modifications for practical purposes.
 
-### Schnorr Signature in a nutshell
-
-Let $p$ be a prime and $E$ be an elliptic curve defined over the finite field $F_p$ with the base point $G$. 
-The signature scheme works as follows:
-
-1. **Key generation:** The secret key $x$ is randomly chosen in $\bmod p$, the  corresponding public key is $X = G \cdot x$.
-
-2. **Signing:** Signer selects a random number $r$ in $\bmod p$, and computes the  nonce $R = G \cdot r$. 
-For the message $m$, signer sets the challenge as $c = H (X, R,  m)$ and computes $s = r + cx$. 
-The signature is obtained as $(R, s)$.
-
-3. **Verification:** The signature is valid if $G \cdot s = R + X \cdot c$.
 
 ### Modifications
 
-- #### Encoding nonce and public key:
+- **Encoding nonce and public key:**
 Instead of encoding full `X`, `Y` coordinates of $R$ and $X$ (64-byte public key, 96-byte signature), or compressed encoding (33-byte public key, 65-byte signature), BIP-430 preferred to use xonly encoding (32-byte public key, 64-byte signature).
 
-- #### Implicit `Y` coordinate:
+- **Implicit `Y` coordinate:**
 Schnorr signatures of BIP-430 implicitly choose the `Y` coordinate that is even.
 
-- #### Tagged hashes:
+- **Tagged hashes:**
 In order to prevent the collisions and reuse of nonce, it is preferred to include the tag by prefixing the hash data with `SHA256(tag) || SHA256(tag)`.
 
 ### Security considerations
@@ -61,117 +62,40 @@ Even if there is an algorithm to solve ECDLP for the xonly encoding, then the fu
 
 ## Adapting MuSig2 to PIB-430
 
-The original scheme of [MuSig2](https://eprint.iacr.org/2020/1261.pdf) is as follows:
+[MuSig2](https://eprint.iacr.org/2020/1261.pdf) 
+is a two-round multi-signature scheme that outputs an ordinary Schnorr signature.
 
-1. **Setup:** Let $p$ be a prime and $E$ be an elliptic curve defined over the finite field $F_p$ with the base point $G$.
+$$ G \cdot s = R + X \cdot c. $$
 
-2. **Key generation:** Every signer selects $x_i$ randomly in $\bmod p$ as secret key, and corresponding public key is $X_i = G \cdot x_i$.
-
-3. **Batch commitment:** Signers create a list of batch commitments including $V$ elements. 
-The commitment of a signer is an elliptic curve point such that $R = G \cdot r$ where $r$ is randomly selected in $\bmod p$. Then, the batch commitments of the system are
-
-$$ {R_{11}, R_{12}, \ldots, R_{1V},\ldots, R_{N1}, \ldots, R_{NV}} $$
-
-where $N$ is the number of signers, and $V$ is the number of nonces.
-
-4. **Aggregate public key:** After receiving the public keys of the registered signers, each signer aggregate the public key as follows:
-
-$$ L = (X_1 || X_2 || \ldots || X_N) $$
-
-$$ a_i = H_{agg}(L || X_i)_{i = 1..N} $$
+The aggregated public key $X$ is generated with the public keys of all signers:
 
 $$ X = \Sigma_{i = 1}^{N} (X_i \cdot a_i) $$
 
-Finally, the signer obtains the public key $X$ and keeps her own $a_i$.
+where $a_i$ is the key aggregate coefficient.
+The commitment $R$ is also generated with the commitments of signers and the nonce $b$.
 
-5. **Aggregate commitments:** After receiving the batch commitment list, a signer computes the aggregate nonce as follows:
+$$ R = \Sigma_{i = 1}^{V}(R_j^{b^{j-1}}). $$
 
-$$ R_i = (R_{i1}, \ldots, R_{iV})_{i = 1..N} $$
+In order to verify MuSig2 by using the function `secp256k1_schnorrsig_verify`, the signature must be obtained by $X$ and $R$ with even `Y` coordinates.
+However, the aggregation of public keys and the commitments may not result points with even `Y` coordinates. 
+Therefore, signers do the following in the single signature generation step:
 
-$$ R_j = (\Sigma_{i = 1}^{V} (R_{ij})_{i = 1..N}) $$
 
-6. **Single signature:** A single signature $s_i$ is generated as:
-
-$$ b = H_{non}(X || (R_1 || \ldots || R_V) || m) $$
-
-$$ R = \Sigma_{i = 1}^{V}(R_j^{b^{j-1}}) $$
-
-$$ c = H_{sig}(X || R || m) $$
-
-$$ s_i = c  a_i x_i + \Sigma_{i = 1}^{V}(r_{ij}   b^{j-1})$$
-
-7. **Aggregate signature:** The aggregate signature $s$ is:
-
-$$ s = \Sigma_{i = 1}^{N}(s_i) $$
-
-So, the MuSig2 is $(R, s)$.
-
-8. **Verification:** The verifier computes $c = H_{sig}(X || R || m)$ and accepts the signature if $G \cdot s = R + X \cdot c$.
-
-### Modifications
-- **Aggregate public key:** To compute the aggregate public key, we need to concatenate the public keys of the signers. 
-Instead of using 64-byte of a full public key, we use only the `X` coordinates of the public keys.
-
-$$ L = ((X_1)_x || \ldots || (X_N)_x). $$
-
-So, the key aggregate coefficient of the signer $i$ is:
-
-$$ a_i = H_{agg}(L || (X_i)_x). $$
-
-The aggregate public key is computed as usual and stored as a full-size public key.
-
-- **Single signature:** We obtain $b$ by hashing (tagged hash) the concatenation of the public key, list of aggregate batch commitments, and the message. 
-The content to be hashed includes only the `X` coordinates of the elliptic curve points:
-
-$$ b = H_{non}((X)_x || ((R_1)_x || \ldots || (R_V)_x) || m). $$
-
-After computing the nonce $R$, the challenge $c$ is computed by using only the $X$ coordinates similarly:
-
-$$ c = H_{sig}((X)_x || (R)_x || m). $$
-
-The signer checks whether the `Y` coordinates of $X$ and $R$ are even or not.
-- **$X$ has odd, $R$ has even `Y` coordinate:** The signer negates $c$.
-- **$X$ has even, $R$ has odd `Y` coordinate:** The signer negates $b$ and $R$.
-- **Both have odd or even `Y` coordinate:** The signer makes no changes.
-
-After the checks, the single signature is calculated as usual.
-
-- **Final signature:** In order to obtain a schnorr signature that can be verified by the `secp256k1_schnorrsig_verify` function, we need the aggregate signature, the xonly encoding of the aggregate public key, and aggregate nonce. 
-However, they may have odd `Y` coordinate, and this will cause the rejection of the MuSig2. 
-Therefore, while generating the final signature, we check whether both $X$ and $R$ have odd `Y` coordinates; if so, the aggregate signature is negated. 
-Other possibilities have already been handled in the single signature step.
-
-### Correctness of the modifications
-
-- **Case 1** *($X$ has odd, $R$ has even `Y` coordinate):* In this case, signer negates $c$.
-
-$$ s_i = - c a_i x_i + \Sigma_{j=1}^{V}(r_{ij} \cdot b^{j-1})$$
-
+- **Case 1** *($X$ has odd, $R$ has even `Y` coordinate):* In this case, signers negate $c$. 
 Negating $c$ is equivalent to negating $X$, since
-
-$$ X = \Sigma_{i=1}^{N} (a_i \cdot X_i) $$
-
-$$ a_i  x_i \cdot G = X_i $$
 
 $$ G \cdot s = R + (-X) \cdot (-c) $$
 
-So, the final signature can be verified successfully by `secp256k1_schnorrsig_verify`.
+- **Case 2** *($X$ has even, $R$ has odd `Y` coordinate)*: In this case, 
+signers negate every element in the list $b^0, b^1, \ldots, b^{V-1}$, so $R$ is also negated.
 
-- **Case 2** *($X$ has even, $R$ has odd `Y` coordinate)*: In this case, signer negates $R$ and every element in the list $b^0, b^1, \ldots, b^{V-1}$.
-  Note that a single signature includes
-
-$$ \Sigma_{j=1}^{V}(r_{ij} b^{j-1}),$$
-
-the aggregate nonce is obtained by
-
-$$ R = \Sigma_{i = 1}^{V}(R_j^{b^{j-1}}) $$
-
-where $R_j$ is the combination of the signers' batch commitments of the form  $R_{ij} = G \cdot r_{ij}$.
-Therefore, the final signature will be valid.
-
-- **Case 3** *(Both have odd `Y` coordinates)*: In this case, we need to negate the aggregate signature since
+- **Case 3** *(Both have odd `Y` coordinates)*: Signers negates their partial signature, so that the aggregated signature will be negated:
 
 $$ G \cdot (-s) = (-R) + (-X) \cdot c. $$
+
+### AOMDL
+The security of MuSig2 depends on the hardness of *algebraic one more discrete logarithm - AOMDL* problem.
+
 
 
 ___

--- a/README.md
+++ b/README.md
@@ -81,20 +81,24 @@ However, the aggregation of public keys and the commitments may not result point
 Therefore, signers do the following in the single signature generation step:
 
 
-- **Case 1** *($X$ has odd, $R$ has even `Y` coordinate):* In this case, signers negate $c$. 
+- **Case 1** ($X$ has odd, $R$ has even `Y` coordinate): In this case, signers negate $c$. 
 Negating $c$ is equivalent to negating $X$, since
 
 $$ G \cdot s = R + (-X) \cdot (-c) $$
 
-- **Case 2** *($X$ has even, $R$ has odd `Y` coordinate)*: In this case, 
+- **Case 2** ($X$ has even, $R$ has odd `Y` coordinate): In this case, 
 signers negate every element in the list $b^0, b^1, \ldots, b^{V-1}$, so $R$ is also negated.
 
-- **Case 3** *(Both have odd `Y` coordinates)*: Signers negates their partial signature, so that the aggregated signature will be negated:
+- **Case 3** (Both have odd `Y` coordinates): Signers negates their partial signature, so that the aggregated signature will be negated:
 
 $$ G \cdot (-s) = (-R) + (-X) \cdot c. $$
 
 ### AOMDL
-The security of MuSig2 depends on the hardness of *algebraic one more discrete logarithm - AOMDL* problem.
+The security of MuSig2 depends on the hardness of *algebraic one more discrete logarithm (AOMDL)* problem. 
+In the standard one more discrete logarithm problem, an adversary is given the public parameters ($E(F_p), G, p$) and wins if it can solve the discrete logarithms ($x_1, \ldots, x_{q+1}$) of $q+1$ challenge group elements ($X_1, \ldots, X_{q+1}$) by only making at most $q$ queries to $D_{LOG}$ oracle.
+The algebraic version of this problem requires to include an algebraic representation $(\alpha, (\beta_i)_{1 \leq i \leq c})$ of the challenge $X$ such $X = G \cdot \alpha + \Sigma_{i=1}^{c}(X_i \cdot \beta_i)$.
+The question is that whether using xonly encoding for the public keys reduce the security of the scheme.
+If there exists a polynomial algorithm to solve AOMDL for xonly encoding of a curve point, then it basically implies that AOMDL is broken for full-size encoding as well, since every `X` coordinate has two possible `Y` coordinate as odd or even. 
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,164 @@
 # MuSig2 Implementation with libsecp256k1
+
 This is a MuSig2 implementation using the libsecp256k1 library for EC operations.
 
 To install the library, follow the directions in [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
-The library provides an optimized C library for ECDSA signatures and secret and public key operations on curve 
-secp256k1, as well as usage examples including ECDSA and Schnorr signatures.
+The library provides an optimized C library for ECDSA signatures and secret and public key operations on curve ecp256k1, as well as usage examples including ECDSA and Schnorr signatures.
 
-This implementation requires to configure the libsecp256k1 with an additional flag 
-`--enable-module-schnorrsig` as stated in [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
+This implementation requires configuring the libsecp256k1 with an additional flag `--enable-module-schnorrsig` as stated in [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
 
-Test the implementation with musig2test.c
+Run the example with examplemusig2.c
 
 ```
-make
-./musig2test
+make ctest
+./ctest_run/ctest
 ```
 
-## Verify MuSig2 with `secp256k1_schnorrsig_verify`
-The standard for 64-byte Schnorr signatures over secp256k1 uses x only encoding for _R_ and PK (aggregated public 
-key _X_ in our case) that results in 32-byte public keys and 64-byte signatures.
-
-Every valid x coordinate has two possible y coordinates, in order to avoid ambiguity the library uses points with 
-even y coordinates. The signature generation and verification are done with using only x coordinates of public key 
-and R since they only have even y coordinates.
-
-However, to obtain _R_ and aggregated public key _X_ with even y coordinates may not be the case for every trial of 
-MuSig2.
-
-The aggregated public key is `X = X_1 * a_1 + ... + X_n * a_n` and _R_ is `R = R_1 * b^(j-1) + ... + R_V * b^(V-1)`.
-
-The verification of MuSig2 checks whether:
+Run the Google tests with
 
 ```
-    G * sig = R + X * c.
+make gtest
+./gtest_run/gtest
 ```
 
-Therefore, we made a little tweak to make sure MuSig2 can be verified by `secp256k1_schnorrsig_verify`.
+## Schnorr Signature of libsecp256k1
 
-1. If _X_ has an odd y coordinate and _R_ has even: **Negate _c_**
+The library offers an optional module implementing Schnorr signatures over the curve `secp256k1`. The scheme is compatible with [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) that produces 64-byte Schnorr signatures. BIP-340 standardized the scheme with some modifications for practical purposes.
 
-2. If _R_ has an odd y coordinate and _X_ has even: **Negate every element in _b_LIST_ and recompute _R_.**
+### Schnorr Signature in a nutshell
 
-3. If both _X_ and _R_ have odd y coordinates: **Negate aggregated signature _agg_sig_.** 
+Let $p$ be a prime and $E$ be an elliptic curve defined over the finite field $F_p$ with the base point $G$. The signature scheme works as follows:
+
+1. **Key generation:** The secret key $x$ is randomly chosen in $\bmod p$, the  corresponding public key is $X = G \cdot x$.
+
+2. **Signing:** Signer selects a random number $r$ in $\bmod p$, and computes the  nonce $R = G \cdot r$. For the message $m$, signer sets the challenge as $c = H (X, R,  m)$ and computes $s = r + cx$. The signature is obtained as $(R, s)$.
+
+3. **Verification:** The signature is valid if $G \cdot s = R + X \cdot c$.
+
+### Modifications
+
+- #### Encoding nonce and public key:
+Instead of encoding full $X$, $Y$ coordinates of $R$ and $X$ (64-byte public key, 96-byte signature), or compressed encoding (33-byte public key, 65-byte signature), BIP-430 preferred to use xonly encoding (32-byte public key, 64-byte signature).
+
+- #### Implicit `Y` coordinate:
+Schnorr signatures of BIP-430 implicitly choose the `Y` coordinate that is even.
+
+- #### Tagged hashes:
+In order to prevent the collisions and reuse of nonce, it is preferred to include the tag by prefixing the hash data with $SHA256(tag) || SHA256(tag)$.
+
+### Security considerations
+
+The xonly encoding of elliptic curve points causes ambiguity since every `X` coordinate has two possible `Y` coordinates. To avoid this ambiguity they chose to select elliptic curve points with even `Y` coordinates.
+The xonly encoding of a point prefixed by the byte `0x02` is equivalent to representing it with a 33-byte but more compact. Moreover, this encoding does not reduce the security of the system. Even if there is an algorithm to solve ECDLP for the xonly encoding, then the full encoding will also be automatically broken since the `X` coordinate has two possible `Y` coordinates as negative and positive.
+
+## Adapting MuSig2 to PIB-430
+
+The original scheme of [MuSig2](https://eprint.iacr.org/2020/1261.pdf) is as follows:
+
+1. **Setup:** Let $p$ be a prime and $E$ be an elliptic curve defined over the finite field $F_p$ with the base point $G$.
+
+2. **Key generation:** Every signer selects $x_i$ randomly in $\bmod p$ as secret key, and corresponding public key is $X_i = G \cdot x_i$.
+
+3. **Batch commitment:** Signers create a list of batch commitments including $V$ elements. The commitment of a signer is an elliptic curve point such that $R = G \cdot r$ where $r$ is randomly selected in $\bmod p$. Then, the batch commitments of the system are
+
+$$ {R_{11}, R_{12}, \ldots, R_{1V},\ldots, R_{N1}, \ldots, R_{NV}} $$
+
+where $N$ is the number of signers, and $V$ is the number of nonces.
+
+4. **Aggregate public key:** After receiving the public keys of the registered signers, each signer aggregate the public key as follows:
+
+$$ L = (X_1 || X_2 || \ldots || X_N) $$
+
+$$ a_i = H_{agg}(L || X_i)_{i = 1..N} $$
+
+$$ X = \Sigma_{i = 1}^{N} (X_i \cdot a_i) $$
+
+Finally, the signer obtains the public key $X$ and keeps her own $a_i$.
+
+5. **Aggregate commitments:** After receiving the batch commitment list, a signer computes the aggregate nonce as follows:
+
+$$ R_i = (R_{i1}, \ldots, R_{iV})_{i = 1..N} $$
+
+$$ R_j = (\Sigma_{i = 1}^{V} (R_{ij})_{i = 1..N}) $$
+
+6. **Single signature:** A single signature $s_i$ is generated as:
+
+$$ b = H_{non}(X || (R_1 || \ldots || R_V) || m) $$
+
+$$ R = \Sigma_{i = 1}^{V}(R_j^{b^{j-1}}) $$
+
+$$ c = H_{sig}(X || R || m) $$
+
+$$ s_i = c  a_i x_i + \Sigma_{i = 1}^{V}(r_{ij}   b^{j-1})$$
+
+7. **Aggregate signature:** The aggregate signature $s$ is:
+
+$$ s = \Sigma_{i = 1}^{N}(s_i) $$
+
+So, the MuSig2 is $(R, s)$.
+
+8. **Verification:** The verifier computes $c = H_{sig}(X || R || m)$ and accepts the signature if $G \cdot s = R + X \cdot c$.
+
+### Modifications
+- **Aggregate public key:** To compute the aggregate public key, we need to concatenate the public keys of the signers. Instead of using 64-byte of a full public key, we use only the `X` coordinates of the public keys.
+
+$$ L = ((X_1)_x || \ldots || (X_N)_x). $$
+
+So, the key aggregate coefficient of the signer $i$ is:
+
+$$ a_i = H_{agg}(L || (X_i)_x). $$
+
+The aggregate public key is computed as usual and stored as a full-size public key.
+
+- **Single signature:** We obtain $b$ by hashing (tagged hash) the concatenation of the public key, list of aggregate batch commitments, and the message. The content to be hashed includes only the `X` coordinates of the elliptic curve points:
+
+$$ b = H_{non}((X)_x || ((R_1)_x || \ldots || (R_V)_x) || m). $$
+
+After computing the nonce $R$, the challenge $c$ is computed by using only the $X$ coordinates similarly:
+
+$$ c = H_{sig}((X)_x || (R)_x || m). $$
+
+The signer checks whether the `Y` coordinates of $X$ and $R$ are even or not.
+- **$X$ has odd, $R$ has even `Y` coordinate:** The signer negates $c$.
+- **$X$ has even, $R$ has odd `Y` coordinate:** The signer negates $b$ and $R$.
+- **Both have odd or even `Y` coordinate:** The signer makes no changes.
+
+After the checks, the single signature is calculated as usual.
+
+- **Final signature:** In order to obtain a schnorr signature that can be verified by the `secp256k1_schnorrsig_verify` function, we need the aggregate signature, the xonly encoding of the aggregate public key, and aggregate nonce. However, they may have odd `Y` coordinate, and this will cause the rejection of the MuSig2. Therefore, while generating the final signature, we check whether both $X$ and $R$ have odd `Y` coordinates; if so, the aggregate signature is negated. Other possibilities have already been handled in the single signature step.
+
+### Correctness of the modifications
+
+- **Case 1 $X$ has odd, $R$ has even `Y` coordinate:** In this case, signer negates $c$.
+
+$$ s_i = - c a_i x_i + \Sigma_{j=1}^{V}(r_{ij} * b^{j-1})$$
+
+Negating $c$ is equivalent to negating $X$, since
+
+$$ X = \Sigma_{i=1}^{N} (a_i * X_i) $$
+
+$$ a_i  x_i \cdot G = X_i $$
+
+$$ G \cdot s = R + (-X) \cdot (-c) $$
+
+So, the final signature can be verified successfully by $secp256k1_schnorrsig_verify$.
+
+- **Case 2 $X$ has even, $R$ has odd `Y` coordinate:** In this case, signer negates $R$ and every element in the list $b^0, b^1, \ldots, b^{V-1}$.
+  Note that a single signature includes
+
+$$ \Sigma_{j=1}^{V}(r_{ij} * b^{j-1}),$$
+
+the aggregate nonce is obtained by
+
+$$ R = \Sigma_{i = 1}^{V}(R_j^{b^{j-1}}) $$
+
+where $R_j$ is the combination of the signers' batch commitments of the form  $R_{ij} = G \cdot r_{ij}$.
+Therefore, the final signature will be valid.
+
+- **Both have odd `Y` coordinates:** In this case, we need to negate the aggregate signature since
+
+$$ G \cdot (-s) = (-R) + (-X) \cdot c. $$
+
 
 ___
 
@@ -50,21 +168,5 @@ ___
 - [x] Prevent reuse of r values.
 - [x] Create musig2 context to simplify the API.
 - [ ] Tests (Valgrind).
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+- [ ] Tests (GoogleTest).
+- [ ] Documentation.

--- a/README.md
+++ b/README.md
@@ -35,43 +35,51 @@ make valgrind
 ```
 
 ## Schnorr Signature of libsecp256k1
-
 The library offers an optional module implementing Schnorr signatures over the curve `secp256k1`. 
 The scheme is compatible with [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) that produces 64-byte Schnorr signatures. 
 BIP-340 standardized the scheme with some modifications for practical purposes.
 
-
 ### Modifications
+For authenticating transactions, ECDSA signatures over the secp256k1 curve with SHA256 hashes are used traditionally 
+and standardized. 
+However, there are several disadvantages compared to Schnorr signatures over the secp256k1 curve. 
+For instance, Schnorr signatures provide linearity, are provably secure (strongly unforgeable under chosen message 
+attack) while the best known results for the provable security of ECDSA rely on stronger assumptions.
+ECDSA signatures are inherently malleable, on the other hand, Schnorr signatures are non-malleable. 
+Furthermore, there are no virtual disadvantages of Schnorr signatures. 
+The motivation is to propose a new standard with some improvements.
+The following are the modifications that relates to the implementation of MuSig2.
 
-- **Encoding nonce and public key:**
-Instead of encoding full `X`, `Y` coordinates of $R$ and $X$ (64-byte public key, 96-byte signature), or compressed encoding (33-byte public key, 65-byte signature), BIP-430 preferred to use xonly encoding (32-byte public key, 64-byte signature).
-
-- **Implicit `Y` coordinate:**
-Schnorr signatures of BIP-430 implicitly choose the `Y` coordinate that is even.
-
-### Security considerations
-
-The xonly encoding of elliptic curve points causes ambiguity since every `X` coordinate has two possible `Y` coordinates. 
-To avoid this ambiguity they chose to select elliptic curve points with even `Y` coordinates.
+- **Encoding nonce and public key:** Instead of encoding full `X`, `Y` coordinates of $R$ and $X$ (64-byte public 
+  key, 96-byte signature), or compressed 
+  encoding (33-byte public key, 65-byte signature, BIP-430 preferred to use xonly encoding (32-byte public key, 
+  64-byte signature).
+- **Implicit `Y` coordinate:** The xonly encoding of elliptic curve points causes ambiguity since every `X` coordinate has two possible `Y` coordinates.
+  To avoid this ambiguity, Schnorr signatures of BIP-430 implicitly chooses the `Y` coordinate that is even, in 
+  other words, xonly encoding is used to represent elliptic curve points that are sent over the wire.
+#### Security considerations
 The xonly encoding of a point is equivalent to representing it with a 33-byte but more compact since only the points with even `Y` coordinate are preferred there is no need to use one extra byte to specify the sign of the point. 
 Moreover, this encoding does not reduce the security of the system (see [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#:~:text=Despite%20halving%20the,8%5D.)). 
-Even if there is an algorithm to solve ECDLP for the xonly encoding, then the full encoding will also be automatically broken since the `X` coordinate has two possible `Y` coordinates as negative and positive.
+Even if there is an algorithm to solve ECDLP for the xonly encoding, then the full encoding will also be 
+automatically broken since the `X` coordinate has only two possible `Y` coordinates.
+
 
 ## Adapting MuSig2 to PIB-430
-
 [MuSig2](https://eprint.iacr.org/2020/1261.pdf) 
 is a two-round multi-signature scheme that outputs an ordinary Schnorr signature. 
 
 1. **Setup:** Let $p$ be a prime and $E$ be an elliptic curve defined over the finite field $F_p$ with the base point $G$ of order $p$.
 
-2. **Key generation:** Every signer selects $x_i$ randomly in $\bmod p$ as secret key, and corresponding public key is $X_i = x_i \cdot G$.
+2. **Key generation:** Every signer selects $x_i$ randomly in $\bmod p$ as secret key, and computes the corresponding 
+   public key as $X_i = x_i \cdot G$.
 
 3. **Batch commitment:** Signers create a list of batch commitments including $V$ elements.
-   The commitment of a signer is an elliptic curve point such that $R = r \cdot G$ where $r$ is randomly selected in $\bmod p$. Then, the batch commitments of the system are
+   The $j^{th}$ commitment of the $i^{th}$ signer is an elliptic curve point such that $R_{ij} = r_{ij} \cdot G$ where 
+   $r_{ij}$ is the nonce, randomly selected in $\bmod p$. Then, the batch commitments of the system are
 
 $$ {R_{11}, R_{12}, \ldots, R_{1V},\ldots, R_{N1}, \ldots, R_{NV}} $$
 
-where $N$ is the number of signers, and $V$ is the number of nonces.
+where $N$ is the number of signers.
 
 4. **Aggregate public key:** After receiving the public keys of the registered signers, each signer aggregate the public key as follows:
 

--- a/README.md
+++ b/README.md
@@ -23,33 +23,41 @@ make gtest
 
 ## Schnorr Signature of libsecp256k1
 
-The library offers an optional module implementing Schnorr signatures over the curve `secp256k1`. The scheme is compatible with [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) that produces 64-byte Schnorr signatures. BIP-340 standardized the scheme with some modifications for practical purposes.
+The library offers an optional module implementing Schnorr signatures over the curve `secp256k1`. 
+The scheme is compatible with [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) that produces 64-byte Schnorr signatures. 
+BIP-340 standardized the scheme with some modifications for practical purposes.
 
 ### Schnorr Signature in a nutshell
 
-Let $p$ be a prime and $E$ be an elliptic curve defined over the finite field $F_p$ with the base point $G$. The signature scheme works as follows:
+Let $p$ be a prime and $E$ be an elliptic curve defined over the finite field $F_p$ with the base point $G$. 
+The signature scheme works as follows:
 
 1. **Key generation:** The secret key $x$ is randomly chosen in $\bmod p$, the  corresponding public key is $X = G \cdot x$.
 
-2. **Signing:** Signer selects a random number $r$ in $\bmod p$, and computes the  nonce $R = G \cdot r$. For the message $m$, signer sets the challenge as $c = H (X, R,  m)$ and computes $s = r + cx$. The signature is obtained as $(R, s)$.
+2. **Signing:** Signer selects a random number $r$ in $\bmod p$, and computes the  nonce $R = G \cdot r$. 
+For the message $m$, signer sets the challenge as $c = H (X, R,  m)$ and computes $s = r + cx$. 
+The signature is obtained as $(R, s)$.
 
 3. **Verification:** The signature is valid if $G \cdot s = R + X \cdot c$.
 
 ### Modifications
 
 - #### Encoding nonce and public key:
-Instead of encoding full $X$, $Y$ coordinates of $R$ and $X$ (64-byte public key, 96-byte signature), or compressed encoding (33-byte public key, 65-byte signature), BIP-430 preferred to use xonly encoding (32-byte public key, 64-byte signature).
+Instead of encoding full `X`, `Y` coordinates of $R$ and $X$ (64-byte public key, 96-byte signature), or compressed encoding (33-byte public key, 65-byte signature), BIP-430 preferred to use xonly encoding (32-byte public key, 64-byte signature).
 
 - #### Implicit `Y` coordinate:
 Schnorr signatures of BIP-430 implicitly choose the `Y` coordinate that is even.
 
 - #### Tagged hashes:
-In order to prevent the collisions and reuse of nonce, it is preferred to include the tag by prefixing the hash data with $SHA256(tag) || SHA256(tag)$.
+In order to prevent the collisions and reuse of nonce, it is preferred to include the tag by prefixing the hash data with `SHA256(tag) || SHA256(tag)`.
 
 ### Security considerations
 
-The xonly encoding of elliptic curve points causes ambiguity since every `X` coordinate has two possible `Y` coordinates. To avoid this ambiguity they chose to select elliptic curve points with even `Y` coordinates.
-The xonly encoding of a point prefixed by the byte `0x02` is equivalent to representing it with a 33-byte but more compact. Moreover, this encoding does not reduce the security of the system. Even if there is an algorithm to solve ECDLP for the xonly encoding, then the full encoding will also be automatically broken since the `X` coordinate has two possible `Y` coordinates as negative and positive.
+The xonly encoding of elliptic curve points causes ambiguity since every `X` coordinate has two possible `Y` coordinates. 
+To avoid this ambiguity they chose to select elliptic curve points with even `Y` coordinates.
+The xonly encoding of a point prefixed by the byte `0x02` is equivalent to representing it with a 33-byte but more compact. 
+Moreover, this encoding does not reduce the security of the system. 
+Even if there is an algorithm to solve ECDLP for the xonly encoding, then the full encoding will also be automatically broken since the `X` coordinate has two possible `Y` coordinates as negative and positive.
 
 ## Adapting MuSig2 to PIB-430
 
@@ -59,7 +67,8 @@ The original scheme of [MuSig2](https://eprint.iacr.org/2020/1261.pdf) is as fol
 
 2. **Key generation:** Every signer selects $x_i$ randomly in $\bmod p$ as secret key, and corresponding public key is $X_i = G \cdot x_i$.
 
-3. **Batch commitment:** Signers create a list of batch commitments including $V$ elements. The commitment of a signer is an elliptic curve point such that $R = G \cdot r$ where $r$ is randomly selected in $\bmod p$. Then, the batch commitments of the system are
+3. **Batch commitment:** Signers create a list of batch commitments including $V$ elements. 
+The commitment of a signer is an elliptic curve point such that $R = G \cdot r$ where $r$ is randomly selected in $\bmod p$. Then, the batch commitments of the system are
 
 $$ {R_{11}, R_{12}, \ldots, R_{1V},\ldots, R_{N1}, \ldots, R_{NV}} $$
 
@@ -100,7 +109,8 @@ So, the MuSig2 is $(R, s)$.
 8. **Verification:** The verifier computes $c = H_{sig}(X || R || m)$ and accepts the signature if $G \cdot s = R + X \cdot c$.
 
 ### Modifications
-- **Aggregate public key:** To compute the aggregate public key, we need to concatenate the public keys of the signers. Instead of using 64-byte of a full public key, we use only the `X` coordinates of the public keys.
+- **Aggregate public key:** To compute the aggregate public key, we need to concatenate the public keys of the signers. 
+Instead of using 64-byte of a full public key, we use only the `X` coordinates of the public keys.
 
 $$ L = ((X_1)_x || \ldots || (X_N)_x). $$
 
@@ -110,7 +120,8 @@ $$ a_i = H_{agg}(L || (X_i)_x). $$
 
 The aggregate public key is computed as usual and stored as a full-size public key.
 
-- **Single signature:** We obtain $b$ by hashing (tagged hash) the concatenation of the public key, list of aggregate batch commitments, and the message. The content to be hashed includes only the `X` coordinates of the elliptic curve points:
+- **Single signature:** We obtain $b$ by hashing (tagged hash) the concatenation of the public key, list of aggregate batch commitments, and the message. 
+The content to be hashed includes only the `X` coordinates of the elliptic curve points:
 
 $$ b = H_{non}((X)_x || ((R_1)_x || \ldots || (R_V)_x) || m). $$
 
@@ -125,28 +136,31 @@ The signer checks whether the `Y` coordinates of $X$ and $R$ are even or not.
 
 After the checks, the single signature is calculated as usual.
 
-- **Final signature:** In order to obtain a schnorr signature that can be verified by the `secp256k1_schnorrsig_verify` function, we need the aggregate signature, the xonly encoding of the aggregate public key, and aggregate nonce. However, they may have odd `Y` coordinate, and this will cause the rejection of the MuSig2. Therefore, while generating the final signature, we check whether both $X$ and $R$ have odd `Y` coordinates; if so, the aggregate signature is negated. Other possibilities have already been handled in the single signature step.
+- **Final signature:** In order to obtain a schnorr signature that can be verified by the `secp256k1_schnorrsig_verify` function, we need the aggregate signature, the xonly encoding of the aggregate public key, and aggregate nonce. 
+However, they may have odd `Y` coordinate, and this will cause the rejection of the MuSig2. 
+Therefore, while generating the final signature, we check whether both $X$ and $R$ have odd `Y` coordinates; if so, the aggregate signature is negated. 
+Other possibilities have already been handled in the single signature step.
 
 ### Correctness of the modifications
 
-- **Case 1 $X$ has odd, $R$ has even `Y` coordinate:** In this case, signer negates $c$.
+- **Case 1** *($X$ has odd, $R$ has even `Y` coordinate):* In this case, signer negates $c$.
 
-$$ s_i = - c a_i x_i + \Sigma_{j=1}^{V}(r_{ij} * b^{j-1})$$
+$$ s_i = - c a_i x_i + \Sigma_{j=1}^{V}(r_{ij} \cdot b^{j-1})$$
 
 Negating $c$ is equivalent to negating $X$, since
 
-$$ X = \Sigma_{i=1}^{N} (a_i * X_i) $$
+$$ X = \Sigma_{i=1}^{N} (a_i \cdot X_i) $$
 
 $$ a_i  x_i \cdot G = X_i $$
 
 $$ G \cdot s = R + (-X) \cdot (-c) $$
 
-So, the final signature can be verified successfully by $secp256k1_schnorrsig_verify$.
+So, the final signature can be verified successfully by `secp256k1_schnorrsig_verify`.
 
-- **Case 2 $X$ has even, $R$ has odd `Y` coordinate:** In this case, signer negates $R$ and every element in the list $b^0, b^1, \ldots, b^{V-1}$.
+- **Case 2** *($X$ has even, $R$ has odd `Y` coordinate)*: In this case, signer negates $R$ and every element in the list $b^0, b^1, \ldots, b^{V-1}$.
   Note that a single signature includes
 
-$$ \Sigma_{j=1}^{V}(r_{ij} * b^{j-1}),$$
+$$ \Sigma_{j=1}^{V}(r_{ij} b^{j-1}),$$
 
 the aggregate nonce is obtained by
 
@@ -155,7 +169,7 @@ $$ R = \Sigma_{i = 1}^{V}(R_j^{b^{j-1}}) $$
 where $R_j$ is the combination of the signers' batch commitments of the form  $R_{ij} = G \cdot r_{ij}$.
 Therefore, the final signature will be valid.
 
-- **Both have odd `Y` coordinates:** In this case, we need to negate the aggregate signature since
+- **Case 3** *(Both have odd `Y` coordinates)*: In this case, we need to negate the aggregate signature since
 
 $$ G \cdot (-s) = (-R) + (-X) \cdot c. $$
 

--- a/readmore.md
+++ b/readmore.md
@@ -1,0 +1,186 @@
+# MuSig2 Implementation with libsecp256k1
+
+This is a MuSig2 implementation using the libsecp256k1 library for EC operations.
+
+To install the library, follow the directions in [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
+The library provides an optimized C library for ECDSA signatures and secret and public key operations on curve ecp256k1, as well as usage examples including ECDSA and Schnorr signatures.
+
+This implementation requires configuring the libsecp256k1 with an additional flag `--enable-module-schnorrsig` as stated in [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
+
+Run the example with examplemusig2.c
+
+```
+make ctest
+./ctest_run/ctest
+```
+
+Run the Google tests with
+
+```
+make gtest
+./gtest_run/gtest
+```
+
+## Schnorr Signature of libsecp256k1
+
+The library offers an optional module implementing Schnorr signatures over the curve `secp256k1`.
+The scheme is compatible with [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) that produces 64-byte Schnorr signatures.
+BIP-340 standardized the scheme with some modifications for practical purposes.
+
+### Schnorr Signature in a nutshell
+
+Let $p$ be a prime and $E$ be an elliptic curve defined over the finite field $F_p$ with the base point $G$.
+The signature scheme works as follows:
+
+1. **Key generation:** The secret key $x$ is randomly chosen in $\bmod p$, the  corresponding public key is $X = G \cdot x$.
+
+2. **Signing:** Signer selects a random number $r$ in $\bmod p$, and computes the  nonce $R = G \cdot r$.
+   For the message $m$, signer sets the challenge as $c = H (X, R,  m)$ and computes $s = r + cx$.
+   The signature is obtained as $(R, s)$.
+
+3. **Verification:** The signature is valid if $G \cdot s = R + X \cdot c$.
+
+### Modifications
+
+- #### Encoding nonce and public key:
+Instead of encoding full `X`, `Y` coordinates of $R$ and $X$ (64-byte public key, 96-byte signature), or compressed encoding (33-byte public key, 65-byte signature), BIP-430 preferred to use xonly encoding (32-byte public key, 64-byte signature).
+
+- #### Implicit `Y` coordinate:
+Schnorr signatures of BIP-430 implicitly choose the `Y` coordinate that is even.
+
+- #### Tagged hashes:
+In order to prevent the collisions and reuse of nonce, it is preferred to include the tag by prefixing the hash data with `SHA256(tag) || SHA256(tag)`.
+
+### Security considerations
+
+The xonly encoding of elliptic curve points causes ambiguity since every `X` coordinate has two possible `Y` coordinates.
+To avoid this ambiguity they chose to select elliptic curve points with even `Y` coordinates.
+The xonly encoding of a point prefixed by the byte `0x02` is equivalent to representing it with a 33-byte but more compact.
+Moreover, this encoding does not reduce the security of the system.
+Even if there is an algorithm to solve ECDLP for the xonly encoding, then the full encoding will also be automatically broken since the `X` coordinate has two possible `Y` coordinates as negative and positive.
+
+## Adapting MuSig2 to PIB-430
+
+The original scheme of [MuSig2](https://eprint.iacr.org/2020/1261.pdf) is as follows:
+
+1. **Setup:** Let $p$ be a prime and $E$ be an elliptic curve defined over the finite field $F_p$ with the base point $G$.
+
+2. **Key generation:** Every signer selects $x_i$ randomly in $\bmod p$ as secret key, and corresponding public key is $X_i = G \cdot x_i$.
+
+3. **Batch commitment:** Signers create a list of batch commitments including $V$ elements.
+   The commitment of a signer is an elliptic curve point such that $R = G \cdot r$ where $r$ is randomly selected in $\bmod p$. Then, the batch commitments of the system are
+
+$$ {R_{11}, R_{12}, \ldots, R_{1V},\ldots, R_{N1}, \ldots, R_{NV}} $$
+
+where $N$ is the number of signers, and $V$ is the number of nonces.
+
+4. **Aggregate public key:** After receiving the public keys of the registered signers, each signer aggregate the public key as follows:
+
+$$ L = (X_1 || X_2 || \ldots || X_N) $$
+
+$$ a_i = H_{agg}(L || X_i)_{i = 1..N} $$
+
+$$ X = \Sigma_{i = 1}^{N} (X_i \cdot a_i) $$
+
+Finally, the signer obtains the public key $X$ and keeps her own $a_i$.
+
+5. **Aggregate commitments:** After receiving the batch commitment list, a signer computes the aggregate nonce as follows:
+
+$$ R_i = (R_{i1}, \ldots, R_{iV})_{i = 1..N} $$
+
+$$ R_j = (\Sigma_{i = 1}^{V} (R_{ij})_{i = 1..N}) $$
+
+6. **Single signature:** A single signature $s_i$ is generated as:
+
+$$ b = H_{non}(X || (R_1 || \ldots || R_V) || m) $$
+
+$$ R = \Sigma_{i = 1}^{V}(R_j^{b^{j-1}}) $$
+
+$$ c = H_{sig}(X || R || m) $$
+
+$$ s_i = c  a_i x_i + \Sigma_{i = 1}^{V}(r_{ij}   b^{j-1})$$
+
+7. **Aggregate signature:** The aggregate signature $s$ is:
+
+$$ s = \Sigma_{i = 1}^{N}(s_i) $$
+
+So, the MuSig2 is $(R, s)$.
+
+8. **Verification:** The verifier computes $c = H_{sig}(X || R || m)$ and accepts the signature if $G \cdot s = R + X \cdot c$.
+
+### Modifications
+- **Aggregate public key:** To compute the aggregate public key, we need to concatenate the public keys of the signers.
+  Instead of using 64-byte of a full public key, we use only the `X` coordinates of the public keys.
+
+$$ L = ((X_1)_x || \ldots || (X_N)_x). $$
+
+So, the key aggregate coefficient of the signer $i$ is:
+
+$$ a_i = H_{agg}(L || (X_i)_x). $$
+
+The aggregate public key is computed as usual and stored as a full-size public key.
+
+- **Single signature:** We obtain $b$ by hashing (tagged hash) the concatenation of the public key, list of aggregate batch commitments, and the message.
+  The content to be hashed includes only the `X` coordinates of the elliptic curve points:
+
+$$ b = H_{non}((X)_x || ((R_1)_x || \ldots || (R_V)_x) || m). $$
+
+After computing the nonce $R$, the challenge $c$ is computed by using only the $X$ coordinates similarly:
+
+$$ c = H_{sig}((X)_x || (R)_x || m). $$
+
+The signer checks whether the `Y` coordinates of $X$ and $R$ are even or not.
+- **$X$ has odd, $R$ has even `Y` coordinate:** The signer negates $c$.
+- **$X$ has even, $R$ has odd `Y` coordinate:** The signer negates $b$ and $R$.
+- **Both have odd or even `Y` coordinate:** The signer makes no changes.
+
+After the checks, the single signature is calculated as usual.
+
+- **Final signature:** In order to obtain a schnorr signature that can be verified by the `secp256k1_schnorrsig_verify` function, we need the aggregate signature, the xonly encoding of the aggregate public key, and aggregate nonce.
+  However, they may have odd `Y` coordinate, and this will cause the rejection of the MuSig2.
+  Therefore, while generating the final signature, we check whether both $X$ and $R$ have odd `Y` coordinates; if so, the aggregate signature is negated.
+  Other possibilities have already been handled in the single signature step.
+
+### Correctness of the modifications
+
+- **Case 1** *($X$ has odd, $R$ has even `Y` coordinate):* In this case, signer negates $c$.
+
+$$ s_i = - c a_i x_i + \Sigma_{j=1}^{V}(r_{ij} \cdot b^{j-1})$$
+
+Negating $c$ is equivalent to negating $X$, since
+
+$$ X = \Sigma_{i=1}^{N} (a_i \cdot X_i) $$
+
+$$ a_i  x_i \cdot G = X_i $$
+
+$$ G \cdot s = R + (-X) \cdot (-c) $$
+
+So, the final signature can be verified successfully by `secp256k1_schnorrsig_verify`.
+
+- **Case 2** *($X$ has even, $R$ has odd `Y` coordinate)*: In this case, signer negates $R$ and every element in the list $b^0, b^1, \ldots, b^{V-1}$.
+  Note that a single signature includes
+
+$$ \Sigma_{j=1}^{V}(r_{ij} b^{j-1}),$$
+
+the aggregate nonce is obtained by
+
+$$ R = \Sigma_{i = 1}^{V}(R_j^{b^{j-1}}) $$
+
+where $R_j$ is the combination of the signers' batch commitments of the form  $R_{ij} = G \cdot r_{ij}$.
+Therefore, the final signature will be valid.
+
+- **Case 3** *(Both have odd `Y` coordinates)*: In this case, we need to negate the aggregate signature since
+
+$$ G \cdot (-s) = (-R) + (-X) \cdot c. $$
+
+
+___
+
+### Progress
+
+- [x] Update the function and parameter namings.
+- [x] Prevent reuse of r values.
+- [x] Create musig2 context to simplify the API.
+- [ ] Tests (Valgrind).
+- [ ] Tests (GoogleTest).
+- [ ] Documentation.

--- a/readmore.md
+++ b/readmore.md
@@ -5,7 +5,7 @@ This is a MuSig2 implementation using the libsecp256k1 library for EC operations
 To install the library, follow the directions in [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
 The library provides an optimized C library for ECDSA signatures and secret and public key operations on curve ecp256k1, as well as usage examples including ECDSA and Schnorr signatures.
 
-This implementation requires configuring the libsecp256k1 with an additional flag `--enable-module-schnorrsig` as stated in [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
+This implementation requires configuring the libsecp256k1 with an additional flag `--enable-module-schnorrsig` as stated in [libsecp256k1](https://github.com/bitcoin-core/secp256k1#build-steps).
 
 Run the example with examplemusig2.c
 
@@ -43,7 +43,7 @@ The signature scheme works as follows:
 ### Modifications
 
 - #### Encoding nonce and public key:
-Instead of encoding full `X`, `Y` coordinates of $R$ and $X$ (64-byte public key, 96-byte signature), or compressed encoding (33-byte public key, 65-byte signature), BIP-430 preferred to use xonly encoding (32-byte public key, 64-byte signature).
+Instead of encoding full `X`, `Y` coordinates of $X$ and $R$ (which results in a 64-byte public key and 96-byte signature), or compressed encoding (33-byte public key, 65-byte signature respectively), BIP-430 preferred to use xonly encoding (32-byte public key, 64-byte signature).
 
 - #### Implicit `Y` coordinate:
 Schnorr signatures of BIP-430 implicitly choose the `Y` coordinate that is even.


### PR DESCRIPTION
Documentation is enhanced to include a more detailed explanation about the libsecp compatibility of MuSig2.

## To Do:

- [x] Update the MuSig2 modifications for the new version in Valgrind PR.
- [x] Explain the security assumptions of MuSig2 and analyze whether changes violate the assumptions.

This PR closes #15. 