### PR TITLE
musig2 wrappers over libsecp

### DIFF
--- a/examplemusig2.c
+++ b/examplemusig2.c
@@ -10,8 +10,8 @@ int main(void) {
     musig2_partial_signature mps1[NR_SIGNERS];  // Array of partial signatures for the first state
     musig2_partial_signature mps2[NR_SIGNERS];  // Array of partial signatures for the second state
 
-    musig2_pubkey aggr_pk_1;    // Aggregate public key of the first state
-    musig2_pubkey aggr_pk_2;    // Aggregate public key of the second state
+    musig2_aggr_pubkey aggr_pk_1;    // Aggregate public key of the first state
+    musig2_aggr_pubkey aggr_pk_2;    // Aggregate public key of the second state
 
     unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Serialized public keys of signers
     unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED]; // Serialized batch commitments
@@ -99,9 +99,9 @@ int main(void) {
 
     if (musig2_aggregate_partial_sig(mps1, signature_1, NR_SIGNERS)){
         printf(" S: ");
-        print_hex(&signature_1[MUSIG2_PUBKEY_BYTES], MUSIG2_PARSIG_BYTES);
+        print_hex(&signature_1[MUSIG2_AGGR_PUBKEY_BYTES], MUSIG2_PARSIG_BYTES);
         printf(" R: ");
-        print_hex(signature_1, MUSIG2_PUBKEY_BYTES);
+        print_hex(signature_1, MUSIG2_AGGR_PUBKEY_BYTES);
     }
     else {
         printf("* Failed to aggregate signatures.\n");
@@ -151,9 +151,9 @@ int main(void) {
 
     if (musig2_aggregate_partial_sig(mps2, signature_2, NR_SIGNERS)){
         printf(" S: ");
-        print_hex(&signature_2[MUSIG2_PUBKEY_BYTES], MUSIG2_PARSIG_BYTES);
+        print_hex(&signature_2[MUSIG2_AGGR_PUBKEY_BYTES], MUSIG2_PARSIG_BYTES);
         printf(" R: ");
-        print_hex(signature_2, MUSIG2_PUBKEY_BYTES);
+        print_hex(signature_2, MUSIG2_AGGR_PUBKEY_BYTES);
     }
     else {
         printf("* Failed to aggregate signatures.\n");

--- a/examplemusig2.c
+++ b/examplemusig2.c
@@ -37,18 +37,26 @@ int main(void) {
         /* Generate a keypair for the signer and get batch commitments. */
         if (musig2_init_signer(&mcs_list[i], NR_MESSAGES)) {
             printf("* Signer %d initialized.\n", i + 1);
+
+            /* Prepare signer to register. */
             unsigned char serialized_comm_list[V * NR_MESSAGES][MUSIG2_PUBKEY_BYTES_COMPRESSED];
             l = 0; // the index of the signer's commitment list.
-            if (musig2_prepare_signer_to_register(&mcs_list[i], &serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_comm_list))
+
+            /* Store the serialized pubkey of the signer */
+            if (musig2_prepare_signer_to_register(&mcs_list[i], &serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_comm_list)) {
                 /* Store the batch commitments of the signer in serialized batch_list */
                 for (k = 0; k < NR_MESSAGES; k++)
                     for (j = 0; j < V; j++, l++)
-                        memcpy(&serialized_batch_list[(k * NR_SIGNERS * V + i * V + j) * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_comm_list[l], MUSIG2_PUBKEY_BYTES_COMPRESSED);
-            else
+                        memcpy(&serialized_batch_list[(k * NR_SIGNERS * V + i * V + j) * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_comm_list[l],
+                               MUSIG2_PUBKEY_BYTES_COMPRESSED);
+            }
+            else {
                 printf("* Failed to register Signer %d.\n", i + 1);
+            }
         }
-        else
+        else {
             printf("* Failed to initialize Signer %d.\n", i + 1);
+        }
     }
     printf("--------------------------------------------------------------------------- \n\n");
 

--- a/examplemusig2.c
+++ b/examplemusig2.c
@@ -19,7 +19,7 @@ int main(void) {
     unsigned char signature1[MUSIG2_BYTES];
     unsigned char signature2[MUSIG2_BYTES];
 
-    int i, j, k, l, ind;
+    int i, j, k, l;
 
 
     printf("--------------------------------------------------------------------------- \n");
@@ -35,22 +35,20 @@ int main(void) {
     /**** Initialization ****/
     for (i = 0; i < NR_SIGNERS; i++) {
         /* Generate a keypair for the signer and get batch commitments. */
-        if (musig2_init_signer(&mcs_list[i], NR_MESSAGES))
+        if (musig2_init_signer(&mcs_list[i], NR_MESSAGES)) {
             printf("* Signer %d initialized.\n", i + 1);
+            unsigned char serialized_comm_list[V * NR_MESSAGES][MUSIG2_PUBKEY_BYTES_COMPRESSED];
+            l = 0; // the index of the signer's commitment list.
+            if (musig2_prepare_signer_to_register(&mcs_list[i], &serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_comm_list))
+                /* Store the batch commitments of the signer in serialized batch_list */
+                for (k = 0; k < NR_MESSAGES; k++)
+                    for (j = 0; j < V; j++, l++)
+                        memcpy(&serialized_batch_list[(k * NR_SIGNERS * V + i * V + j) * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_comm_list[l], MUSIG2_PUBKEY_BYTES_COMPRESSED);
+            else
+                printf("* Failed to register Signer %d.\n", i + 1);
+        }
         else
             printf("* Failed to initialize Signer %d.\n", i + 1);
-
-        /* Store the public key of the signer in pk_list */
-        assert(musig2_pubkey_from_keypair_serialize(&mcs_list[i].keypair, &serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED]));
-
-        /* Store the batch commitments of the signer in serialized batch_list */
-        l = 0; // the index of the signer's commitment list.
-        for (k = 0; k < NR_MESSAGES; k++) {
-            for (j = 0; j < V; j++, l++) {
-                ind = (k * NR_SIGNERS * V + i * V + j) * MUSIG2_PUBKEY_BYTES_COMPRESSED;
-                assert(musig2_pubkey_from_keypair_serialize(mcs_list[i].comm_list[l], &serialized_batch_list[ind]));
-            }
-        }
     }
     printf("--------------------------------------------------------------------------- \n\n");
 

--- a/examplemusig2.c
+++ b/examplemusig2.c
@@ -34,13 +34,24 @@ int main(void) {
 
     /**** Initialization ****/
     for (i = 0; i < NR_SIGNERS; i++) {
-        unsigned char serialized_comm_list[V * NR_MESSAGES][MUSIG2_PUBKEY_BYTES_COMPRESSED];
-        unsigned char serialized_pk[MUSIG2_PUBKEY_BYTES_COMPRESSED];
-
         /* Generate a keypair for the signer and get batch commitments. */
-        if (musig2_init_signer(&mcs_list[i], serialized_pk, serialized_comm_list, NR_MESSAGES)) {
+        if (musig2_init_signer(&mcs_list[i], NR_MESSAGES)) {
             printf("* Signer %d initialized.\n", i + 1);
-            memcpy(&serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_pk, MUSIG2_PUBKEY_BYTES_COMPRESSED);
+        }
+        else {
+            printf("* Failed to initialize Signer %d.\n", i + 1);
+        }
+    }
+    printf("--------------------------------------------------------------------------- \n\n");
+
+    /**** Registration ****/
+    for (i = 0; i < NR_SIGNERS; i++) {
+        unsigned char serialized_comm_list[V * NR_MESSAGES][MUSIG2_PUBKEY_BYTES_COMPRESSED];
+        unsigned char serialized_pubkey[MUSIG2_PUBKEY_BYTES_COMPRESSED];
+
+        if (musig2_serialise_shareable_context(&mcs_list[i], serialized_pubkey, serialized_comm_list)){
+            printf("* Signer %d registered.\n", i + 1);
+            memcpy(&serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_pubkey, MUSIG2_PUBKEY_BYTES_COMPRESSED);
             l = 0; // the index of the signer's commitment list.
             for (k = 0; k < NR_MESSAGES; k++)
                 for (j = 0; j < V; j++, l++)
@@ -49,7 +60,7 @@ int main(void) {
 
         }
         else {
-            printf("* Failed to initialize Signer %d.\n", i + 1);
+            printf("* Failed to register Signer %d.\n", i + 1);
         }
     }
     printf("--------------------------------------------------------------------------- \n\n");

--- a/examplemusig2.c
+++ b/examplemusig2.c
@@ -68,7 +68,6 @@ int main(void) {
     /**** Aggregate the public keys and batch commitments for each signer for all messages ****/
     for (i = 0; i < NR_SIGNERS; i++) {
         if (!musig2_signer_precomputation(&mcs_list[i].mc, serialized_pk_list, serialized_batch_list, NR_SIGNERS, NR_MESSAGES)) {
-            musig2_context_sig_free(&mcs_list[k]);
             return -1;
         }
     }
@@ -87,7 +86,6 @@ int main(void) {
         }
         else {
             printf("* Failed to generate signature for Signer %d.\n", i + 1);
-            musig2_context_sig_free(&mcs_list[k]);
             return -1;
         }
     }
@@ -115,7 +113,7 @@ int main(void) {
 
     musig2_prepare_verifier(&aggr_pk_1, serialized_pk_list, NR_SIGNERS);
     /* Verify the aggregated signature with secp256k1_schnorrsig_verify */
-    if (musig2_verify_musig2(signature_1, MSG_1, MSG_1_LEN, &aggr_pk_1))
+    if (musig2_verify(signature_1, MSG_1, MSG_1_LEN, &aggr_pk_1))
         printf("\n* Musig2 is VALID!\n");
     else
         printf("\n* Failed to verify Musig2!\n");
@@ -168,7 +166,7 @@ int main(void) {
 
     musig2_prepare_verifier(    &aggr_pk_2, serialized_pk_list, NR_SIGNERS);
     /* Verify the aggregated signature with secp256k1_schnorrsig_verify */
-    if (musig2_verify_musig2(signature_2, MSG_2, MSG_2_LEN, &aggr_pk_2))
+    if (musig2_verify(signature_2, MSG_2, MSG_2_LEN, &aggr_pk_2))
         printf("\n* Musig2 is VALID!\n");
     else
         printf("\n* Failed to verify Musig2!\n");

--- a/src/libmusig2.c
+++ b/src/libmusig2.c
@@ -1,7 +1,7 @@
 #include "libmusig2.h"
 
 static int musig2_key_gen(musig2_context_sig *mcs) {
-    unsigned char x[SCALAR_BYTES];
+    unsigned char x[MUSIG2_SCALAR_BYTES];
 
     while (1) {
         if (!fill_random(x, sizeof(x))) {
@@ -16,7 +16,7 @@ static int musig2_key_gen(musig2_context_sig *mcs) {
 
 static int musig2_batch_commitment(musig2_context_sig *mcs) {
 
-    unsigned char x[SCALAR_BYTES];
+    unsigned char x[MUSIG2_SCALAR_BYTES];
     mcs->comm_list = malloc(sizeof (secp256k1_keypair*) * mcs->mc.nr_messages * V);
 
     int i, j, k;
@@ -26,7 +26,7 @@ static int musig2_batch_commitment(musig2_context_sig *mcs) {
         for (j = 0; j < V; j++, i++) {
             mcs->comm_list[i] = malloc(sizeof(secp256k1_keypair));
             while (1) {
-                if (!fill_random(x, SCALAR_BYTES)) {
+                if (!fill_random(x, MUSIG2_SCALAR_BYTES)) {
                     return 0;
                 }
                 if (secp256k1_keypair_create(mcs->mc.ctx, mcs->comm_list[i], x))
@@ -40,10 +40,10 @@ static int musig2_batch_commitment(musig2_context_sig *mcs) {
 static void musig2_key_agg_coef(musig2_context *mc, unsigned char *ser_pk, unsigned char *a) {
 
     unsigned char tag[13] = "BIP0340/nonce";    // Tag of hash to generate the exponents
-    unsigned char temp_concat[(mc->nr_signers + 1) * XONLY_BYTES];    // Temp to store the concatenation of public keys
+    unsigned char temp_concat[(mc->nr_signers + 1) * MUSIG2_PUBKEY_BYTES];    // Temp to store the concatenation of public keys
 
-    memcpy(temp_concat, mc->L, mc->nr_signers * XONLY_BYTES );      // Copy L into temp_concat
-    memcpy(&temp_concat[mc->nr_signers * XONLY_BYTES], ser_pk, XONLY_BYTES );  /* Copy given pk besides L */
+    memcpy(temp_concat, mc->L, mc->nr_signers * MUSIG2_PUBKEY_BYTES );      // Copy L into temp_concat
+    memcpy(&temp_concat[mc->nr_signers * MUSIG2_PUBKEY_BYTES], ser_pk, MUSIG2_PUBKEY_BYTES );  /* Copy given pk besides L */
     assert(secp256k1_tagged_sha256(mc->ctx, a, tag, sizeof (tag), temp_concat, sizeof (temp_concat)));
 }
 
@@ -51,29 +51,29 @@ static void musig2_calc_b(musig2_context *mc, const unsigned char *ser_aggr_pk, 
 
     int j;
     unsigned char tag[13] = "BIP0340/nonce";    // Tag for the hash to compute b
-    unsigned char ser_R[XONLY_BYTES];
-    unsigned char temp_concat[(1 + V) * XONLY_BYTES + msg_len]; // Temp value to store the concatenation of aggr_pk, aggr_R_list and the message.
+    unsigned char ser_R[MUSIG2_PUBKEY_BYTES];
+    unsigned char temp_concat[(1 + V) * MUSIG2_PUBKEY_BYTES + msg_len]; // Temp value to store the concatenation of aggr_pk, aggr_R_list and the message.
     secp256k1_xonly_pubkey xonly_R;
 
     /* Copy ser_aggr_pk into temp_concat */
-    memcpy(temp_concat, ser_aggr_pk, XONLY_BYTES);
+    memcpy(temp_concat, ser_aggr_pk, MUSIG2_PUBKEY_BYTES);
 
     /* Get x_only R_j, serialize and concatenate. */
     for (j = 0; j < V; j++) {
         assert(secp256k1_xonly_pubkey_from_pubkey(mc->ctx, &xonly_R, NULL, mc->aggr_R_list[state * V + j]));
         secp256k1_xonly_pubkey_serialize(mc->ctx, ser_R, &xonly_R);
-        memcpy(&temp_concat[XONLY_BYTES * (j + 1)], ser_R, XONLY_BYTES);
+        memcpy(&temp_concat[MUSIG2_PUBKEY_BYTES * (j + 1)], ser_R, MUSIG2_PUBKEY_BYTES);
     }
 
     /* Concatenate msg to end */
-    memcpy(&temp_concat[(1 + V) * XONLY_BYTES], msg, msg_len);
+    memcpy(&temp_concat[(1 + V) * MUSIG2_PUBKEY_BYTES], msg, msg_len);
 
     /* Compute b */
     assert(secp256k1_tagged_sha256(mc->ctx, b, tag, sizeof (tag), temp_concat, sizeof(temp_concat)));
 
 }
 
-static int musig2_calc_R(musig2_context *mc, secp256k1_xonly_pubkey *aggr_R, int *par_R, unsigned char *b, unsigned char b_LIST[V][SCALAR_BYTES], int state) {
+static int musig2_calc_R(musig2_context *mc, secp256k1_xonly_pubkey *aggr_R, int *par_R, unsigned char *b, unsigned char b_LIST[V][MUSIG2_SCALAR_BYTES], int state) {
 
     int j;
     secp256k1_pubkey tweakable_Rb_list[V];
@@ -82,14 +82,14 @@ static int musig2_calc_R(musig2_context *mc, secp256k1_xonly_pubkey *aggr_R, int
     secp256k1_xonly_pubkey xonly_temp;   // temp value to store xonly point
 
     for (j = 0; j < V; j++)
-        memcpy(tweakable_Rb_list[j].data, mc->aggr_R_list[state * V + j]->data, PK_BYTES);
+        memcpy(tweakable_Rb_list[j].data, mc->aggr_R_list[state * V + j]->data, MUSIG2_PUBKEY_BYTES_FULL);
     /* Compute b_LIST = { b^(j-1) } and Rb_LIST = { R_j * b^(j-1) } */
     b_LIST[0][31] = 1; // first element of b_LIST = 1;
     Rb_list[0] = &tweakable_Rb_list[0];
 
     for (j = 1; j < V; j++) {
         Rb_list[j] = &tweakable_Rb_list[j];
-        memcpy(b_LIST[j], b_LIST[j-1], SCALAR_BYTES);
+        memcpy(b_LIST[j], b_LIST[j-1], MUSIG2_SCALAR_BYTES);
         if (!secp256k1_ec_seckey_tweak_mul(mc->ctx, b_LIST[j], b))
             return 0;
 
@@ -121,11 +121,11 @@ static int musig2_calc_R(musig2_context *mc, secp256k1_xonly_pubkey *aggr_R, int
     return 1;
 }
 
-static int musig2_set_parsig(musig2_context_sig *mcs, unsigned char *a, unsigned char *c, unsigned char b_LIST[V][SCALAR_BYTES], int *par_R, unsigned char *parsig) {
+static int musig2_set_parsig(musig2_context_sig *mcs, unsigned char *a, unsigned char *c, unsigned char b_LIST[V][MUSIG2_SCALAR_BYTES], int par_R, unsigned char *parsig) {
     int j;
-    unsigned char temp_rb[SCALAR_BYTES];
-    unsigned char x[SCALAR_BYTES];
-    unsigned char sr_list[V][SCALAR_BYTES];
+    unsigned char temp_rb[MUSIG2_SCALAR_BYTES];
+    unsigned char x[MUSIG2_SCALAR_BYTES];
+    unsigned char sr_list[V][MUSIG2_SCALAR_BYTES];
 
     /* Extract the secret key of the signer */
     assert(secp256k1_keypair_sec(mcs->mc.ctx, x, &mcs->keypair));
@@ -141,26 +141,26 @@ static int musig2_set_parsig(musig2_context_sig *mcs, unsigned char *a, unsigned
     mcs->state++;
 
     // Condition where R is even and PK is odd. We negate the challenge
-    if (*par_R == 0 && mcs->mc.par_pk == 1){
+    if (par_R == 0 && mcs->mc.par_pk == 1){
         if (!secp256k1_ec_seckey_negate(mcs->mc.ctx, c)){
             return 0;
         }
     }
 
     /* Compute (a * x * c) */
-    memcpy(parsig, c, SCALAR_BYTES);
+    memcpy(parsig, c, MUSIG2_SCALAR_BYTES);
     if (!secp256k1_ec_seckey_tweak_mul(mcs->mc.ctx, parsig, x) || !secp256k1_ec_seckey_tweak_mul(mcs->mc.ctx, parsig, a))
         return 0;
 
     /* Finalise the computation of a * x * c + \sum_{i=0}^V r_i * b_i */
     for (j = 0; j < V; j++) {
-        memcpy(temp_rb, sr_list[j], SCALAR_BYTES);
+        memcpy(temp_rb, sr_list[j], MUSIG2_SCALAR_BYTES);
         if (!secp256k1_ec_seckey_tweak_mul(mcs->mc.ctx, temp_rb, b_LIST[j]) || !secp256k1_ec_seckey_tweak_add(mcs->mc.ctx, parsig, temp_rb))
             return 0;
     }
 
     // The third condition, if both R and pk are odd, we negate the partial signature.
-    if (*par_R == 1 && mcs->mc.par_pk == 1){
+    if (par_R == 1 && mcs->mc.par_pk == 1){
         if (!secp256k1_ec_seckey_negate(mcs->mc.ctx, parsig)){
             return 0;
         }
@@ -193,9 +193,26 @@ void musig2_context_sig_free(musig2_context_sig *mcs) {
     musig2_context_free(&mcs->mc);
 }
 
+int musig2_pubkey_from_keypair_serialize(secp256k1_context *ctx, secp256k1_keypair *keypair, unsigned char *serialized_pubkey){
+    secp256k1_pubkey temp_pk;
+    size_t ser_size = MUSIG2_PUBKEY_BYTES_COMPRESSED;
+
+    if (!secp256k1_keypair_pub(ctx, &temp_pk, keypair))
+        return 0;
+
+    secp256k1_ec_pubkey_serialize(ctx, serialized_pubkey, &ser_size, &temp_pk, SECP256K1_EC_COMPRESSED );
+    return 1;
+}
+
 /**** Signer ****/
 int musig2_init_signer(musig2_context_sig *mcs, secp256k1_context *ctx, int nr_messages) {
 
+    /* Initialize the secp256k1_context to operate on secp256k1 curve.
+     * MuSig2 library generates a multi-signature in the form of the schnorr signature obtained by secp256k1_schnorrsig_sign32
+     * with the library functions of libsecp256k1, however we do not use secp256k1_schnorrsig_sign32 function.
+     * Thus, we create the context with only SECP256K1_CONTEXT_VERIFY flag instead of using
+     * SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY. */
+    ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
     mcs->mc.ctx = ctx;
     mcs->state = 0;
     mcs->mc.nr_messages = nr_messages;
@@ -214,25 +231,25 @@ int musig2_init_signer(musig2_context_sig *mcs, secp256k1_context *ctx, int nr_m
 int musig2_aggregate_pubkey(musig2_context *mc, secp256k1_pubkey *pk_list) {
 
     int i;
-    unsigned char temp_a[SCALAR_BYTES];
-    unsigned char ser_pk_list[mc->nr_signers][XONLY_BYTES];
+    unsigned char temp_a[MUSIG2_SCALAR_BYTES];
+    unsigned char ser_pk_list[mc->nr_signers][MUSIG2_PUBKEY_BYTES];
     secp256k1_pubkey tweakable_pk_list[mc->nr_signers];
     const secp256k1_pubkey* pk_pointer_list[mc->nr_signers];
     secp256k1_xonly_pubkey temp_xonly_pk;
 
     /* Allocate memory for L */
-    mc->L = malloc(XONLY_BYTES * mc->nr_signers);
+    mc->L = malloc(MUSIG2_PUBKEY_BYTES * mc->nr_signers);
 
     /* Multiply pk_i with a_i. Store in temp_pk_list[i]. */
     for (i = 0; i < mc->nr_signers; i++) {
         /* Copy the current public key into temp_pk_list */
-        memcpy(tweakable_pk_list[i].data, pk_list[i].data, PK_BYTES);
+        memcpy(tweakable_pk_list[i].data, pk_list[i].data, MUSIG2_PUBKEY_BYTES_FULL);
         pk_pointer_list[i] = &tweakable_pk_list[i];
         assert(secp256k1_xonly_pubkey_from_pubkey(mc->ctx, &temp_xonly_pk, NULL, pk_pointer_list[i]));
         secp256k1_xonly_pubkey_serialize(mc->ctx, ser_pk_list[i], &temp_xonly_pk);
 
         /* Update L */
-        memcpy(&mc->L[i * XONLY_BYTES], ser_pk_list[i], XONLY_BYTES);
+        memcpy(&mc->L[i * MUSIG2_PUBKEY_BYTES], ser_pk_list[i], MUSIG2_PUBKEY_BYTES);
     }
 
     for (i = 0; i < mc->nr_signers; i++) {
@@ -277,11 +294,11 @@ int musig2_signer_precomputation(musig2_context *mc, unsigned char *serialized_p
 
     // Parse the batch commitments of the signers
     for (i = 0; i < nr_signers; i++) {
-        assert(secp256k1_ec_pubkey_parse(mc->ctx, &pk_list[i], &serialized_pk_list[i * SER_PK_BYTES_COMPRESSED], SER_PK_BYTES_COMPRESSED));
+        assert(secp256k1_ec_pubkey_parse(mc->ctx, &pk_list[i], &serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], MUSIG2_PUBKEY_BYTES_COMPRESSED));
         for (k = 0; k < nr_messages; k++) {
             for (j = 0; j < V; j++) {
-                ind = (k * nr_signers * V + i * V + j) * SER_PK_BYTES_COMPRESSED;
-                assert(secp256k1_ec_pubkey_parse(mc->ctx, &batch_list[k][i][j], &serialized_batch_list[ind], SER_PK_BYTES_COMPRESSED));
+                ind = (k * nr_signers * V + i * V + j) * MUSIG2_PUBKEY_BYTES_COMPRESSED;
+                assert(secp256k1_ec_pubkey_parse(mc->ctx, &batch_list[k][i][j], &serialized_batch_list[ind], MUSIG2_PUBKEY_BYTES_COMPRESSED));
             }
         }
     }
@@ -299,13 +316,13 @@ int musig2_signer_precomputation(musig2_context *mc, unsigned char *serialized_p
 
 int musig2_sign(musig2_context_sig *mcs, musig2_partial_signature *mps, const unsigned char *msg, int msg_len) {
 
-    unsigned char ser_aggr_pk[XONLY_BYTES];
-    unsigned char ser_aggr_R[XONLY_BYTES];
-    unsigned char bytes_to_hash[XONLY_BYTES * 2 + msg_len];   // Temp to store ( ser_xonly_R || ser_xonly_X_ || msg_hash )
-    unsigned char a[SCALAR_BYTES], b[SCALAR_BYTES], c[SCALAR_BYTES];
-    unsigned char b_LIST[V][SCALAR_BYTES] = {0};
+    unsigned char ser_aggr_pk[MUSIG2_PUBKEY_BYTES];
+    unsigned char ser_aggr_R[MUSIG2_PUBKEY_BYTES];
+    unsigned char bytes_to_hash[MUSIG2_PUBKEY_BYTES * 2 + msg_len];   // Temp to store ( ser_xonly_R || ser_xonly_X_ || msg_hash )
+    unsigned char a[MUSIG2_SCALAR_BYTES], b[MUSIG2_SCALAR_BYTES], c[MUSIG2_SCALAR_BYTES];
+    unsigned char b_LIST[V][MUSIG2_SCALAR_BYTES] = {0};
 
-    unsigned char ser_pk[XONLY_BYTES];  // Serialized public key of signer
+    unsigned char ser_pk[MUSIG2_PUBKEY_BYTES];  // Serialized public key of signer
     secp256k1_xonly_pubkey xonly_temp;
     int par_R;
 
@@ -333,13 +350,13 @@ int musig2_sign(musig2_context_sig *mcs, musig2_partial_signature *mps, const un
 
     secp256k1_xonly_pubkey_serialize(mcs->mc.ctx, ser_aggr_R, &mps->R);
 
-    memcpy(bytes_to_hash, &ser_aggr_R, XONLY_BYTES);
-    memcpy(&bytes_to_hash[XONLY_BYTES], &ser_aggr_pk, XONLY_BYTES);
-    memcpy(&bytes_to_hash[XONLY_BYTES * 2], msg, msg_len);
+    memcpy(bytes_to_hash, &ser_aggr_R, MUSIG2_PUBKEY_BYTES);
+    memcpy(&bytes_to_hash[MUSIG2_PUBKEY_BYTES], &ser_aggr_pk, MUSIG2_PUBKEY_BYTES);
+    memcpy(&bytes_to_hash[MUSIG2_PUBKEY_BYTES * 2], msg, msg_len);
 
     assert(secp256k1_tagged_sha256(mcs->mc.ctx, c, (const unsigned char *)"BIP0340/challenge" , 17, bytes_to_hash, sizeof (bytes_to_hash)));
 
-    if (!musig2_set_parsig(mcs, a, c, b_LIST, &par_R, mps->sig))
+    if (!musig2_set_parsig(mcs, a, c, b_LIST, par_R, mps->sig))
         return 0;
 
 
@@ -361,9 +378,9 @@ int musig2_aggregate_partial_sig(secp256k1_context *ctx, musig2_partial_signatur
     secp256k1_xonly_pubkey_serialize(ctx, signature, &mps[0].R);
 
     /* Aggregate the partial signatures */
-    memcpy(signature + XONLY_BYTES, mps[0].sig, SCALAR_BYTES);
+    memcpy(signature + MUSIG2_PUBKEY_BYTES, mps[0].sig, MUSIG2_SCALAR_BYTES);
     for (i = 1; i < nr_signatures; i++) {
-        if (!secp256k1_ec_seckey_tweak_add(ctx, signature + XONLY_BYTES, mps[i].sig))
+        if (!secp256k1_ec_seckey_tweak_add(ctx, signature + MUSIG2_PUBKEY_BYTES, mps[i].sig))
             return 0;
 
     }
@@ -371,7 +388,7 @@ int musig2_aggregate_partial_sig(secp256k1_context *ctx, musig2_partial_signatur
     return 1;
 }
 
-void musig2_prepare_verifier(secp256k1_context *ctx, secp256k1_xonly_pubkey *aggr_pk, unsigned char *serialized_pk_list, int nr_signers) {
+void musig2_prepare_verifier(secp256k1_context *ctx, musig2_pubkey *aggr_pk, unsigned char *serialized_pk_list, int nr_signers) {
     musig2_context verifier_context;
     verifier_context.aggr_R_list = NULL;
     verifier_context.nr_signers = nr_signers;
@@ -379,7 +396,7 @@ void musig2_prepare_verifier(secp256k1_context *ctx, secp256k1_xonly_pubkey *agg
 
     int i;
     for (i = 0; i < nr_signers; i++)
-        assert(secp256k1_ec_pubkey_parse(ctx, &pk_list[i], &serialized_pk_list[i * SER_PK_BYTES_COMPRESSED], SER_PK_BYTES_COMPRESSED));
+        assert(secp256k1_ec_pubkey_parse(ctx, &pk_list[i], &serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], MUSIG2_PUBKEY_BYTES_COMPRESSED));
 
     musig2_aggregate_pubkey(&verifier_context, pk_list);
 

--- a/src/libmusig2.c
+++ b/src/libmusig2.c
@@ -169,7 +169,6 @@ static int musig2_set_parsig(musig2_context_sig *mcs, unsigned char *a, unsigned
     return 1;
 }
 
-/*** Free memory allocated in MuSig2 context ***/
 void musig2_context_free(musig2_context *mc) {
     if (mc->ctx != NULL) {
         secp256k1_context_destroy(mc->ctx);
@@ -187,7 +186,6 @@ void musig2_context_free(musig2_context *mc) {
     }
 }
 
-/*** Free memory allocated in MuSig2 Sig context ***/
 void musig2_context_sig_free(musig2_context_sig *mcs) {
     for (int l = mcs->state * V; l < mcs->mc.nr_messages * V; l++) {
         free(mcs->comm_list[l]);
@@ -215,7 +213,6 @@ int musig2_serialise_shareable_context(musig2_context_sig *mcs, unsigned char *s
     return 1;
 }
 
-/**** Signer ****/
 int musig2_init_signer(musig2_context_sig *mcs, int nr_messages) {
 
     mcs->mc.ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
@@ -371,7 +368,6 @@ int musig2_sign(musig2_context_sig *mcs, musig2_partial_signature *mps, const un
     return 1;
 }
 
-/**** Aggregator ****/
 int musig2_aggregate_partial_sig(musig2_partial_signature *mps, unsigned char *signature, int nr_signatures) {
     int i;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);

--- a/src/libmusig2.c
+++ b/src/libmusig2.c
@@ -196,30 +196,27 @@ void musig2_context_sig_free(musig2_context_sig *mcs) {
     musig2_context_free(&mcs->mc);
 }
 
-int musig2_prepare_signer_to_register(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_batch_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED]){
+int musig2_serialise_shareable_context(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_batch_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED]){
     secp256k1_pubkey temp_pk;
     size_t ser_size = MUSIG2_PUBKEY_BYTES_COMPRESSED;
     int i;
 
     if (secp256k1_keypair_pub(mcs->mc.ctx, &temp_pk, &mcs->keypair))
         secp256k1_ec_pubkey_serialize(mcs->mc.ctx, serialized_pubkey, &ser_size, &temp_pk, SECP256K1_EC_COMPRESSED );
-    else {
+    else
         return 0;
-    }
 
-    for (i = 0; i < mcs->mc.nr_messages * V; i++) {
+    for (i = 0; i < mcs->mc.nr_messages * V; i++)
         if (secp256k1_keypair_pub(mcs->mc.ctx, &temp_pk, mcs->comm_list[i]))
             secp256k1_ec_pubkey_serialize(mcs->mc.ctx, serialized_batch_list[i], &ser_size, &temp_pk, SECP256K1_EC_COMPRESSED );
-        else {
+        else
             return 0;
-        }
-    }
 
     return 1;
 }
 
 /**** Signer ****/
-int musig2_init_signer(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_comm_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED], int nr_messages) {
+int musig2_init_signer(musig2_context_sig *mcs, int nr_messages) {
 
     mcs->mc.ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
     mcs->state = 0;
@@ -233,10 +230,6 @@ int musig2_init_signer(musig2_context_sig *mcs, unsigned char *serialized_pubkey
 
     /* Generate the batch commitments for given signer */
     if (!musig2_batch_commitment(mcs)) {
-        return 0;
-    }
-
-    if (!musig2_prepare_signer_to_register(mcs, serialized_pubkey, serialized_comm_list)){
         return 0;
     }
 

--- a/src/libmusig2.c
+++ b/src/libmusig2.c
@@ -430,3 +430,12 @@ void musig2_prepare_verifier(musig2_pubkey *aggr_pk, unsigned char *serialized_p
 
     musig2_context_free(&verifier_context);
 }
+
+int musig2_verify_musig2(unsigned char *signature, const unsigned char *msg, int msg_len, musig2_pubkey *aggr_pk){
+    int result;
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    result = secp256k1_schnorrsig_verify(ctx, signature, msg, msg_len, aggr_pk);
+
+    secp256k1_context_destroy(ctx);
+    return result;
+}

--- a/src/libmusig2.c
+++ b/src/libmusig2.c
@@ -204,7 +204,6 @@ int musig2_prepare_signer_to_register(musig2_context_sig *mcs, unsigned char *se
     if (secp256k1_keypair_pub(mcs->mc.ctx, &temp_pk, &mcs->keypair))
         secp256k1_ec_pubkey_serialize(mcs->mc.ctx, serialized_pubkey, &ser_size, &temp_pk, SECP256K1_EC_COMPRESSED );
     else {
-        musig2_context_sig_free(mcs);
         return 0;
     }
 
@@ -212,7 +211,6 @@ int musig2_prepare_signer_to_register(musig2_context_sig *mcs, unsigned char *se
         if (secp256k1_keypair_pub(mcs->mc.ctx, &temp_pk, mcs->comm_list[i]))
             secp256k1_ec_pubkey_serialize(mcs->mc.ctx, serialized_batch_list[i], &ser_size, &temp_pk, SECP256K1_EC_COMPRESSED );
         else {
-            musig2_context_sig_free(mcs);
             return 0;
         }
     }
@@ -235,12 +233,10 @@ int musig2_init_signer(musig2_context_sig *mcs, unsigned char *serialized_pubkey
 
     /* Generate the batch commitments for given signer */
     if (!musig2_batch_commitment(mcs)) {
-        musig2_context_sig_free(mcs);
         return 0;
     }
 
     if (!musig2_prepare_signer_to_register(mcs, serialized_pubkey, serialized_comm_list)){
-        musig2_context_sig_free(mcs);
         return 0;
     }
 

--- a/src/libmusig2.c
+++ b/src/libmusig2.c
@@ -221,7 +221,6 @@ int musig2_init_signer(musig2_context_sig *mcs, int nr_messages) {
 
     /* Generate a key pair for given signer */
     if (!musig2_key_gen(mcs)) {
-        musig2_context_sig_free(mcs);
         return 0;
     }
 
@@ -416,7 +415,7 @@ void musig2_prepare_verifier(musig2_aggr_pubkey *aggr_pk, unsigned char *seriali
     musig2_context_free(&verifier_context);
 }
 
-int musig2_verify_musig2(unsigned char *signature, const unsigned char *msg, int msg_len, musig2_aggr_pubkey *aggr_pk){
+int musig2_verify(unsigned char *signature, const unsigned char *msg, int msg_len, musig2_aggr_pubkey *aggr_pk){
     int result;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
     result = secp256k1_schnorrsig_verify(ctx, signature, msg, msg_len, aggr_pk);

--- a/src/libmusig2.h
+++ b/src/libmusig2.h
@@ -162,7 +162,7 @@ int musig2_signer_precomputation(musig2_context *mc, unsigned char *serialized_p
  * */
 int musig2_serialise_shareable_context(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_batch_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED]);
 
-/** Function    : musig2_verify_musig2
+/** Function    : musig2_verify
  *  Purpose     : Verifies given signature of given message with secp256k1_schnorrsig_verify.
                   If verification succeeds, it returns 1, 0 otherwise.
  *  Parameters  : IN        : signature: musig2_context_sig object.
@@ -171,5 +171,5 @@ int musig2_serialise_shareable_context(musig2_context_sig *mcs, unsigned char *s
  *                          : aggr_pk: Verification key of the signature.
  * Returns      : 1/0.
  * */
-int musig2_verify_musig2(unsigned char *signature, const unsigned char *msg, int msg_len, musig2_aggr_pubkey *aggr_pk);
+int musig2_verify(unsigned char *signature, const unsigned char *msg, int msg_len, musig2_aggr_pubkey *aggr_pk);
 

--- a/src/libmusig2.h
+++ b/src/libmusig2.h
@@ -121,18 +121,18 @@ int musig2_sign(musig2_context_sig *mcs, musig2_partial_signature *mps, const un
  *                          : mps: The list of partial signatures and R values of signers.
  *                          : pk_list: The list of public keys.
  *                          : nr_signatures: The number of signatures.
- * Returns      : 1/0.
+ * Returns      : 1/0/-1.
  * */
 int musig2_aggregate_partial_sig(musig2_partial_signature *mps, unsigned char *signature, int nr_signatures);
 
 /** Function    : musig2_prepare_verifier
  *  Purpose     : Prepares verification for schnorr verifier function. Aggregates the public key and serialises
- *                to the format accepted by schorr_verify.
+ *                to the format accepted by schnorr_verify.
  *  Parameters  : IN/OUT    : aggr_pk: serialised aggregated public key.
  *              : IN        : ctx: secp256k1_context object.
  *                          : pk_list: list of public keys from all signers
  *                          : nr_signers: the total number of signers/keys submitted.
- */
+ * */
 void musig2_prepare_verifier(musig2_aggr_pubkey *aggr_pk, unsigned char *serialized_pk_list, int nr_signers);
 
 
@@ -147,10 +147,29 @@ void musig2_prepare_verifier(musig2_aggr_pubkey *aggr_pk, unsigned char *seriali
  *                          : serialized_batch_list: The string including the list of serialized batch commitments of all signers for all states.
  *                          : nr_signers: the total number of signers/keys submitted.
  *                          : nr_messages: the number of messages to be signed.
- */
+ * Returns      : 1/0.
+ * */
 int musig2_signer_precomputation(musig2_context *mc, unsigned char *serialized_pk_list, unsigned char *serialized_batch_list, int nr_signers, int nr_messages);
 
+/** Function    : musig2_serialise_shareable_context
+ *  Purpose     : Serializes the shareable content in compressed (33-byte) form. Takes musig2_context_sig as input which includes the public key and the
+ *                commitment list of the signer. Public key and the commitments are stored within keypair type in the struct, thus before serialization,
+ *                public key content is extracted from keypair. If all content converted and serialized successfully, it returns 1, 0 otherwise.
+ *  Parameters  : IN/OUT    : serialized_pubkey: 33-byte serialized public key.
+ *                          : serialized_batch_list: The list of 33-byte serialized commitments.
+ *              : IN        : mcs: musig2_context_sig object.
+ * Returns      : 1/0.
+ * */
 int musig2_serialise_shareable_context(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_batch_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED]);
 
+/** Function    : musig2_verify_musig2
+ *  Purpose     : Verifies given signature of given message with secp256k1_schnorrsig_verify.
+                  If verification succeeds, it returns 1, 0 otherwise.
+ *  Parameters  : IN        : signature: musig2_context_sig object.
+ *                          : msg: Message of the signature to be verified.
+ *                          : msg_len: Length of the message.
+ *                          : aggr_pk: Verification key of the signature.
+ * Returns      : 1/0.
+ * */
 int musig2_verify_musig2(unsigned char *signature, const unsigned char *msg, int msg_len, musig2_aggr_pubkey *aggr_pk);
 

--- a/src/libmusig2.h
+++ b/src/libmusig2.h
@@ -81,7 +81,7 @@ void musig2_context_sig_free(musig2_context_sig *mcs);
  *                          : nr_messages: The number of messages.
  * Returns      : 1/0.
  * */
-int musig2_init_signer(musig2_context_sig *mcs, secp256k1_context *ctx, int nr_messages);
+int musig2_init_signer(musig2_context_sig *mcs, int nr_messages);
 
 /** Function    : musig2_aggregate_pubkey
  *  Purpose     : Aggregates the given list of public keys.
@@ -123,7 +123,7 @@ int musig2_sign(musig2_context_sig *mcs, musig2_partial_signature *mps, const un
  *                          : nr_signatures: The number of signatures.
  * Returns      : 1/0.
  * */
-int musig2_aggregate_partial_sig(secp256k1_context *ctx, musig2_partial_signature *mps, unsigned char *signature, int nr_signatures);
+int musig2_aggregate_partial_sig(musig2_partial_signature *mps, unsigned char *signature, int nr_signatures);
 
 /** Function    : musig2_prepare_verifier
  *  Purpose     : Prepares verification for schnorr verifier function. Aggregates the public key and serialises
@@ -133,7 +133,7 @@ int musig2_aggregate_partial_sig(secp256k1_context *ctx, musig2_partial_signatur
  *                          : pk_list: list of public keys from all signers
  *                          : nr_signers: the total number of signers/keys submitted.
  */
-void musig2_prepare_verifier(secp256k1_context *ctx, musig2_pubkey *aggr_pk, unsigned char *serialized_pk_list, int nr_signers);
+void musig2_prepare_verifier(musig2_pubkey *aggr_pk, unsigned char *serialized_pk_list, int nr_signers);
 
 
 /** Function    : musig2_signer_precomputation
@@ -158,4 +158,4 @@ int musig2_signer_precomputation(musig2_context *mc, unsigned char *serialized_p
  *                          : keypair: secp256k1_keypair object.
  *  Returns     : 1/0.
  */
-int musig2_pubkey_from_keypair_serialize(secp256k1_context *ctx, secp256k1_keypair *keypair, unsigned char *serialized_pubkey);
+int musig2_pubkey_from_keypair_serialize(secp256k1_keypair *keypair, unsigned char *serialized_pubkey);

--- a/src/libmusig2.h
+++ b/src/libmusig2.h
@@ -151,3 +151,6 @@ void musig2_prepare_verifier(musig2_pubkey *aggr_pk, unsigned char *serialized_p
 int musig2_signer_precomputation(musig2_context *mc, unsigned char *serialized_pk_list, unsigned char *serialized_batch_list, int nr_signers, int nr_messages);
 
 int musig2_prepare_signer_to_register(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_batch_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED]);
+
+int musig2_verify_musig2(unsigned char *signature, const unsigned char *msg, int msg_len, musig2_pubkey *aggr_pk);
+

--- a/src/libmusig2.h
+++ b/src/libmusig2.h
@@ -81,7 +81,7 @@ void musig2_context_sig_free(musig2_context_sig *mcs);
  *                          : nr_messages: The number of messages.
  * Returns      : 1/0.
  * */
-int musig2_init_signer(musig2_context_sig *mcs, int nr_messages);
+int musig2_init_signer(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_comm_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED], int nr_messages);
 
 /** Function    : musig2_aggregate_pubkey
  *  Purpose     : Aggregates the given list of public keys.

--- a/src/libmusig2.h
+++ b/src/libmusig2.h
@@ -81,7 +81,7 @@ void musig2_context_sig_free(musig2_context_sig *mcs);
  *                          : nr_messages: The number of messages.
  * Returns      : 1/0.
  * */
-int musig2_init_signer(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_comm_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED], int nr_messages);
+int musig2_init_signer(musig2_context_sig *mcs, int nr_messages);
 
 /** Function    : musig2_aggregate_pubkey
  *  Purpose     : Aggregates the given list of public keys.
@@ -150,7 +150,7 @@ void musig2_prepare_verifier(musig2_pubkey *aggr_pk, unsigned char *serialized_p
  */
 int musig2_signer_precomputation(musig2_context *mc, unsigned char *serialized_pk_list, unsigned char *serialized_batch_list, int nr_signers, int nr_messages);
 
-int musig2_prepare_signer_to_register(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_batch_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED]);
+int musig2_serialise_shareable_context(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_batch_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED]);
 
 int musig2_verify_musig2(unsigned char *signature, const unsigned char *msg, int msg_len, musig2_pubkey *aggr_pk);
 

--- a/src/libmusig2.h
+++ b/src/libmusig2.h
@@ -9,15 +9,19 @@
 #include "random.h"
 
 
-// todo: use the secp library constants
-#define V                               2           // Number of nonce values
-#define SCALAR_BYTES                    32          // SCALAR BYTES
-#define XONLY_BYTES                     32          // XONLY PUBLIC KEY BYTES
-#define PAR_SIG_BYTES                   32          // PARTIAL SIGNATURE BYTES
-#define PK_BYTES                        64          // FULL SIZE PUBLIC KEY BYTES
-#define SCH_SIG_BYTES                   64          // SCHNORR SIGNATURE BYTES
-#define SER_PK_BYTES_COMPRESSED         33          // Serialized public key bytes for compressed version
+#define V                                   2           // Number of nonce values
+#define MUSIG2_SCALAR_BYTES                 32          // SCALAR BYTES
+#define MUSIG2_PARSIG_BYTES                 32          // PARTIAL SIGNATURE BYTES
+#define MUSIG2_PUBKEY_BYTES                 32          // XONLY PUBLIC KEY BYTES
+#define MUSIG2_PUBKEY_BYTES_COMPRESSED      33          // COMPRESSED PUBLIC KEY BYTES
+#define MUSIG2_PUBKEY_BYTES_FULL            64          // FULL SIZE PUBLIC KEY BYTES
+#define MUSIG2_BYTES                        64          // SCHNORR SIGNATURE BYTES
 
+
+/** Type        : musig2_pubkey
+ *  Purpose     : MuSig2 public key as secp256k1_xonly_pubkey.
+* */
+typedef secp256k1_xonly_pubkey musig2_pubkey;
 
 /** Struct      : musig2_context
  *  Purpose     : Stores the parameters of musig2.
@@ -59,7 +63,7 @@ typedef struct {
  *              : R: The aggregated commitment of the signature.
  * */
 typedef struct{
-    unsigned char sig[PAR_SIG_BYTES];
+    unsigned char sig[MUSIG2_PARSIG_BYTES];
     secp256k1_xonly_pubkey R;
 }musig2_partial_signature;
 
@@ -129,7 +133,7 @@ int musig2_aggregate_partial_sig(secp256k1_context *ctx, musig2_partial_signatur
  *                          : pk_list: list of public keys from all signers
  *                          : nr_signers: the total number of signers/keys submitted.
  */
-void musig2_prepare_verifier(secp256k1_context *ctx, secp256k1_xonly_pubkey *aggr_pk, unsigned char *serialized_pk_list, int nr_signers);
+void musig2_prepare_verifier(secp256k1_context *ctx, musig2_pubkey *aggr_pk, unsigned char *serialized_pk_list, int nr_signers);
 
 
 /** Function    : musig2_signer_precomputation
@@ -145,3 +149,13 @@ void musig2_prepare_verifier(secp256k1_context *ctx, secp256k1_xonly_pubkey *agg
  *                          : nr_messages: the number of messages to be signed.
  */
 int musig2_signer_precomputation(musig2_context *mc, unsigned char *serialized_pk_list, unsigned char *serialized_batch_list, int nr_signers, int nr_messages);
+
+/** Function    : musig2_pubkey_from_keypair_serialize
+ *  Purpose     : Extracts the secp256k1_pubkey from secp256k1_keypair, outputs 33-byte serialized pubkey in compressed format.
+ *                If given keypair is invalid, returns 0, 1 otherwise.
+ *  Parameters  : IN/OUT    : serialized_pubkey: 33-byte serialized pubkey.
+ *              : IN        : ctx: secp256k1_context object.
+ *                          : keypair: secp256k1_keypair object.
+ *  Returns     : 1/0.
+ */
+int musig2_pubkey_from_keypair_serialize(secp256k1_context *ctx, secp256k1_keypair *keypair, unsigned char *serialized_pubkey);

--- a/src/libmusig2.h
+++ b/src/libmusig2.h
@@ -150,12 +150,4 @@ void musig2_prepare_verifier(musig2_pubkey *aggr_pk, unsigned char *serialized_p
  */
 int musig2_signer_precomputation(musig2_context *mc, unsigned char *serialized_pk_list, unsigned char *serialized_batch_list, int nr_signers, int nr_messages);
 
-/** Function    : musig2_pubkey_from_keypair_serialize
- *  Purpose     : Extracts the secp256k1_pubkey from secp256k1_keypair, outputs 33-byte serialized pubkey in compressed format.
- *                If given keypair is invalid, returns 0, 1 otherwise.
- *  Parameters  : IN/OUT    : serialized_pubkey: 33-byte serialized pubkey.
- *              : IN        : ctx: secp256k1_context object.
- *                          : keypair: secp256k1_keypair object.
- *  Returns     : 1/0.
- */
-int musig2_pubkey_from_keypair_serialize(secp256k1_keypair *keypair, unsigned char *serialized_pubkey);
+int musig2_prepare_signer_to_register(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_batch_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED]);

--- a/src/libmusig2.h
+++ b/src/libmusig2.h
@@ -12,16 +12,16 @@
 #define V                                   2           // Number of nonce values
 #define MUSIG2_SCALAR_BYTES                 32          // SCALAR BYTES
 #define MUSIG2_PARSIG_BYTES                 32          // PARTIAL SIGNATURE BYTES
-#define MUSIG2_PUBKEY_BYTES                 32          // XONLY PUBLIC KEY BYTES
+#define MUSIG2_AGGR_PUBKEY_BYTES            32          // XONLY PUBLIC KEY BYTES
 #define MUSIG2_PUBKEY_BYTES_COMPRESSED      33          // COMPRESSED PUBLIC KEY BYTES
 #define MUSIG2_PUBKEY_BYTES_FULL            64          // FULL SIZE PUBLIC KEY BYTES
 #define MUSIG2_BYTES                        64          // SCHNORR SIGNATURE BYTES
 
 
-/** Type        : musig2_pubkey
+/** Type        : musig2_aggr_pubkey
  *  Purpose     : MuSig2 public key as secp256k1_xonly_pubkey.
 * */
-typedef secp256k1_xonly_pubkey musig2_pubkey;
+typedef secp256k1_xonly_pubkey musig2_aggr_pubkey;
 
 /** Struct      : musig2_context
  *  Purpose     : Stores the parameters of musig2.
@@ -133,7 +133,7 @@ int musig2_aggregate_partial_sig(musig2_partial_signature *mps, unsigned char *s
  *                          : pk_list: list of public keys from all signers
  *                          : nr_signers: the total number of signers/keys submitted.
  */
-void musig2_prepare_verifier(musig2_pubkey *aggr_pk, unsigned char *serialized_pk_list, int nr_signers);
+void musig2_prepare_verifier(musig2_aggr_pubkey *aggr_pk, unsigned char *serialized_pk_list, int nr_signers);
 
 
 /** Function    : musig2_signer_precomputation
@@ -152,5 +152,5 @@ int musig2_signer_precomputation(musig2_context *mc, unsigned char *serialized_p
 
 int musig2_serialise_shareable_context(musig2_context_sig *mcs, unsigned char *serialized_pubkey, unsigned char serialized_batch_list[][MUSIG2_PUBKEY_BYTES_COMPRESSED]);
 
-int musig2_verify_musig2(unsigned char *signature, const unsigned char *msg, int msg_len, musig2_pubkey *aggr_pk);
+int musig2_verify_musig2(unsigned char *signature, const unsigned char *msg, int msg_len, musig2_aggr_pubkey *aggr_pk);
 

--- a/tests/functiontest.c
+++ b/tests/functiontest.c
@@ -25,7 +25,7 @@ TEST (musig2, valid_signature) {
     ASSERT_EQ(err, 1);
 
     // Aggregate partial signatures for `NR_SIGNERS`..
-    err = musig2_aggregate_partial_sig(ctx, mps, signature, NR_SIGNERS);
+    err = musig2_aggregate_partial_sig(mps, signature, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     err = musig2_ver_musig(ctx, signature, mcs_list[0].mc.aggr_pk, MSG_1, MSG_1_LEN);
@@ -56,7 +56,7 @@ TEST (musig2, not_enough_signatures) {
     ASSERT_EQ(err, 1);
 
     // Aggregate partial signatures for `NR_SIGNERS`..
-    err = musig2_aggregate_partial_sig(ctx, mps, signature, less_signers);
+    err = musig2_aggregate_partial_sig(mps, signature, less_signers);
     ASSERT_EQ(err, 1);
 
     err = musig2_ver_musig(ctx, signature, mcs_list[0].mc.aggr_pk, MSG_1, MSG_1_LEN);
@@ -87,7 +87,7 @@ TEST (musig2, non_corresponding_signers) {
     ASSERT_EQ(err, 1);
 
     // Aggregate partial signatures for ``mcs_list[0], ..., mcs_list[NR_SIGNERS - 1]`.
-    err = musig2_aggregate_partial_sig(ctx, mps, signature, NR_SIGNERS);
+    err = musig2_aggregate_partial_sig(mps, signature, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     // Verify the aggregated signature with secp256k1_schnorrsig_verify
@@ -126,7 +126,7 @@ TEST (musig2, incorrect_aggregated_commitment_of_nonces) {
     assert(secp256k1_xonly_pubkey_from_pubkey(ctx, &mps[0].R, NULL, &tmp));
 
     // Aggregation of partial signatures should fail since one of the signatures have incorrect aggregated commitment of nonce.
-    err = musig2_aggregate_partial_sig(ctx, mps, signature, NR_SIGNERS);
+    err = musig2_aggregate_partial_sig(mps, signature, NR_SIGNERS);
     ASSERT_EQ(err, -1);
 
     // Verify the aggregated signature with secp256k1_schnorrsig_verify
@@ -161,7 +161,7 @@ TEST (musig2, previous_state) {
     err = sign_partial(mcs_list, mps1, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
-    err = musig2_aggregate_partial_sig(ctx, mps1, signature1, NR_SIGNERS);
+    err = musig2_aggregate_partial_sig(mps1, signature1, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     err = musig2_ver_musig(ctx, signature1, mcs_list[0].mc.aggr_pk, MSG_1, MSG_1_LEN);
@@ -185,7 +185,7 @@ TEST (musig2, previous_state) {
     }
 
     // Aggregation should fail.
-    err = musig2_aggregate_partial_sig(ctx, mps2, signature2, NR_SIGNERS);
+    err = musig2_aggregate_partial_sig(mps2, signature2, NR_SIGNERS);
     ASSERT_EQ(err, -1);
 
     // Verification should fail.
@@ -216,7 +216,7 @@ TEST (musig2, future_state) {
     err = sign_partial(mcs_list, mps, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
-    err = musig2_aggregate_partial_sig(ctx, mps, signature, NR_SIGNERS);
+    err = musig2_aggregate_partial_sig(mps, signature, NR_SIGNERS);
     ASSERT_EQ(err, -1);
 
     // Verification should fail since one of the signers' signature used a future state.
@@ -246,7 +246,7 @@ TEST (musig2, invalid_signer_key) {
     err = sign_partial(mcs_list, mps, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
-    err = musig2_aggregate_partial_sig(ctx, mps, signature, NR_SIGNERS);
+    err = musig2_aggregate_partial_sig(mps, signature, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     // Verification should fail since one of the signers' key is incorrect.
@@ -277,7 +277,7 @@ TEST (musig2, invalid_single_signature) {
     // Flip a bit of a single signature.
     mps[0].sig[0] ^= 1;
 
-    err = musig2_aggregate_partial_sig(ctx, mps, signature, NR_SIGNERS);
+    err = musig2_aggregate_partial_sig(mps, signature, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     // Verification should fail since one of the single signatures is incorrect.
@@ -307,7 +307,7 @@ TEST (musig2, aggregate_invalid_public_key) {
     err = sign_partial(mcs_list, mps, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
-    err = musig2_aggregate_partial_sig(ctx, mps, signature, NR_SIGNERS);
+    err = musig2_aggregate_partial_sig(mps, signature, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     // Verification should fail since one of the signers' public key is incorrect.

--- a/tests/functiontest.c
+++ b/tests/functiontest.c
@@ -1,4 +1,3 @@
-#include <gtest/gtest.h>
 extern "C" {
 
 
@@ -6,11 +5,11 @@ TEST (musig2, valid_signature) {
 
     int err;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[NR_SIGNERS * SER_PK_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
     musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
     musig2_partial_signature mps[NR_SIGNERS];
-    unsigned char signature[SCH_SIG_BYTES];
-    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * SER_PK_BYTES_COMPRESSED];
+    unsigned char signature[MUSIG2_BYTES];
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
 
     // Init signers, store public keys, generate batch commitments for `NR_SIGNERS`.
@@ -38,11 +37,11 @@ TEST (musig2, not_enough_signatures) {
 
     int err;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[NR_SIGNERS * SER_PK_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
     musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
     musig2_partial_signature mps[less_signers];
-    unsigned char signature[SCH_SIG_BYTES];
-    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * SER_PK_BYTES_COMPRESSED];
+    unsigned char signature[MUSIG2_BYTES];
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     // Init signers, store public keys, generate batch commitments for `NR_SIGNERS`.
     err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
@@ -69,11 +68,11 @@ TEST (musig2, non_corresponding_signers) {
 
     int err;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[nr_participants * SER_PK_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_pk_list[nr_participants * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
     musig2_context_sig mcs_list[nr_participants]; // Array that holds NR_SIGNERS musig2_context_sig
     musig2_partial_signature mps[NR_SIGNERS];
-    unsigned char signature[SCH_SIG_BYTES];
-    unsigned char serialized_batch_list[nr_participants * NR_SIGNERS * V * SER_PK_BYTES_COMPRESSED];
+    unsigned char signature[MUSIG2_BYTES];
+    unsigned char serialized_batch_list[nr_participants * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     // Init signers, store public keys, create batch commitments for `nr_participants`.
     err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, nr_participants);
@@ -102,13 +101,13 @@ TEST (musig2, incorrect_aggregated_commitment_of_nonces) {
 
     int err;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[NR_SIGNERS * SER_PK_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
     secp256k1_pubkey tmp;
     musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
     musig2_partial_signature mps[NR_SIGNERS];
-    unsigned char signature[SCH_SIG_BYTES];
-    unsigned char tweak[SCALAR_BYTES] = {7};
-    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * SER_PK_BYTES_COMPRESSED];
+    unsigned char signature[MUSIG2_BYTES];
+    unsigned char tweak[MUSIG2_SCALAR_BYTES] = {7};
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     // Init signers, store public keys, generate batch commitments for `NR_SIGNERS`.
     err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
@@ -141,13 +140,13 @@ TEST (musig2, previous_state) {
 
     int i, err;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[NR_SIGNERS * SER_PK_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
     musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
     musig2_partial_signature mps1[NR_SIGNERS];
     musig2_partial_signature mps2[NR_SIGNERS];
-    unsigned char signature1[SCH_SIG_BYTES];
-    unsigned char signature2[SCH_SIG_BYTES];
-    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * SER_PK_BYTES_COMPRESSED];
+    unsigned char signature1[MUSIG2_BYTES];
+    unsigned char signature2[MUSIG2_BYTES];
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
     /******************************************************************************************************************/
 
     /*** STATE = 0 ****************************************************************************************************/
@@ -200,11 +199,11 @@ TEST (musig2, future_state) {
 
     int err;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[NR_SIGNERS * SER_PK_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
     musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
     musig2_partial_signature mps[NR_SIGNERS];
-    unsigned char signature[SCH_SIG_BYTES];
-    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * SER_PK_BYTES_COMPRESSED];
+    unsigned char signature[MUSIG2_BYTES];
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
@@ -230,11 +229,11 @@ TEST (musig2, invalid_signer_key) {
 
     int err;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[NR_SIGNERS * SER_PK_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
     musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
     musig2_partial_signature mps[NR_SIGNERS];
-    unsigned char signature[SCH_SIG_BYTES];
-    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * SER_PK_BYTES_COMPRESSED];
+    unsigned char signature[MUSIG2_BYTES];
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
@@ -260,11 +259,11 @@ TEST (musig2, invalid_single_signature) {
 
     int err;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[NR_SIGNERS * SER_PK_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
     musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
     musig2_partial_signature mps[NR_SIGNERS];
-    unsigned char signature[SCH_SIG_BYTES];
-    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * SER_PK_BYTES_COMPRESSED];
+    unsigned char signature[MUSIG2_BYTES];
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
@@ -291,11 +290,11 @@ TEST (musig2, aggregate_invalid_public_key) {
 
     int err;
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[NR_SIGNERS * SER_PK_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
     musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
     musig2_partial_signature mps[NR_SIGNERS];
-    unsigned char signature[SCH_SIG_BYTES];
-    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * SER_PK_BYTES_COMPRESSED];
+    unsigned char signature[MUSIG2_BYTES];
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);

--- a/tests/functiontest.c
+++ b/tests/functiontest.c
@@ -13,7 +13,7 @@ TEST (musig2, valid_signature) {
 
 
     // Init signers, store public keys, generate batch commitments for `NR_SIGNERS`.
-    err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     // Aggregate public keys and batch commitments.
@@ -44,7 +44,7 @@ TEST (musig2, not_enough_signatures) {
     unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     // Init signers, store public keys, generate batch commitments for `NR_SIGNERS`.
-    err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     // Aggregate public keys and batch commitments.
@@ -75,7 +75,7 @@ TEST (musig2, non_corresponding_signers) {
     unsigned char serialized_batch_list[nr_participants * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     // Init signers, store public keys, create batch commitments for `nr_participants`.
-    err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, nr_participants);
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, nr_participants);
     ASSERT_EQ(err, 1);
 
     // Aggregate public keys and batch commitments for `mcs_list[1], ..., mcs_list[NR_SIGNERS]`.
@@ -110,7 +110,7 @@ TEST (musig2, incorrect_aggregated_commitment_of_nonces) {
     unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     // Init signers, store public keys, generate batch commitments for `NR_SIGNERS`.
-    err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     err = aggregate_pk_batch(serialized_pk_list, serialized_batch_list, mcs_list);
@@ -152,7 +152,7 @@ TEST (musig2, previous_state) {
     /*** STATE = 0 ****************************************************************************************************/
     // Musig2 proceeds as it is supposed to do for the first state.
 
-    err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     err = aggregate_pk_batch(serialized_pk_list, serialized_batch_list, mcs_list);
@@ -205,7 +205,7 @@ TEST (musig2, future_state) {
     unsigned char signature[MUSIG2_BYTES];
     unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
-    err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     err = aggregate_pk_batch(serialized_pk_list, serialized_batch_list, mcs_list);
@@ -235,7 +235,7 @@ TEST (musig2, invalid_signer_key) {
     unsigned char signature[MUSIG2_BYTES];
     unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
-    err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     err = aggregate_pk_batch(serialized_pk_list, serialized_batch_list, mcs_list);
@@ -265,7 +265,7 @@ TEST (musig2, invalid_single_signature) {
     unsigned char signature[MUSIG2_BYTES];
     unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
-    err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     err = aggregate_pk_batch(serialized_pk_list, serialized_batch_list, mcs_list);
@@ -296,7 +296,7 @@ TEST (musig2, aggregate_invalid_public_key) {
     unsigned char signature[MUSIG2_BYTES];
     unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
-    err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     // Flip a bit of one of the signers' public key.

--- a/tests/serdetest.c
+++ b/tests/serdetest.c
@@ -1,4 +1,3 @@
-#include <gtest/gtest.h>
 extern "C" {
 
 
@@ -7,11 +6,11 @@ TEST (musig2, pk_list_serialize_deserialize) {
     int i, err;
     size_t ser_size = 33; // Size of the compressed ec pubkey of secp256k1.
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[NR_SIGNERS * SER_PK_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
     secp256k1_pubkey batch_list[NR_SIGNERS * V * NR_MESSAGES];   // Stores the batches of signers
     musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
     secp256k1_pubkey serde_pk_list[NR_SIGNERS];
-    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * SER_PK_BYTES_COMPRESSED];
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
 
     err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);

--- a/tests/serdetest.c
+++ b/tests/serdetest.c
@@ -37,7 +37,7 @@ TEST (musig2, commitments_serialize_deserialize) {
 
     int j, k, l, ind;
     for (i = 0; i < NR_SIGNERS; i++) {
-        if (musig2_init_signer(&mcs_list[i], ctx, NR_MESSAGES)) {
+        if (musig2_init_signer(&mcs_list[i], NR_MESSAGES)) {
 // Store the public key of the signer in pk_list
             assert (secp256k1_keypair_pub(ctx, &pk_list[i], &mcs_list[i].keypair));
 

--- a/tests/serdetest.c
+++ b/tests/serdetest.c
@@ -4,63 +4,54 @@ extern "C" {
 TEST (musig2, pk_list_serialize_deserialize) {
 
     int i, err;
-    size_t ser_size = 33; // Size of the compressed ec pubkey of secp256k1.
-    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
-    secp256k1_pubkey batch_list[NR_SIGNERS * V * NR_MESSAGES];   // Stores the batches of signers
-    musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
-    secp256k1_pubkey serde_pk_list[NR_SIGNERS];
-    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
+    size_t ser_size = MUSIG2_PUBKEY_BYTES_COMPRESSED; // Size of the compressed ec pubkey of secp256k1.
 
-    err = init_musig2(ctx, serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
+    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
+    unsigned char serde_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
+
+    secp256k1_pubkey batch_list[NR_SIGNERS * V * NR_MESSAGES];   // Stores the batches of signers
+    secp256k1_pubkey deser_pk_list[NR_SIGNERS];
+
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
     ASSERT_EQ(err, 1);
 
     for (i = 0; i < NR_SIGNERS; i++)
-        assert(secp256k1_ec_pubkey_parse(ctx, &serde_pk_list[i], &serialized_pk_list[i * ser_size], ser_size));
+        ASSERT_EQ(secp256k1_ec_pubkey_parse(ctx, &deser_pk_list[i], &serialized_pk_list[i * ser_size], ser_size), 1);
 
-//    for (i = 0; i < NR_SIGNERS; i++){
-//        err = secp256k1_ec_pubkey_cmp(ctx, &pk_list[i], &serde_pk_list[i]);
-//        ASSERT_EQ(err, 0);
-//    }
+    for (i = 0; i < NR_SIGNERS; i++)
+        secp256k1_ec_pubkey_serialize(ctx, &serde_pk_list[i * ser_size], &ser_size, &deser_pk_list[i], SECP256K1_EC_COMPRESSED);
+
+    for (i = 0; i < NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED; i++)
+        ASSERT_EQ(serde_pk_list[i], serialized_pk_list[i]);
 }
 
 TEST (musig2, commitments_serialize_deserialize) {
 
     int i, err;
-    size_t ser_size = 33; // Size of the compressed ec pubkey of secp256k1.
+    size_t ser_size = MUSIG2_PUBKEY_BYTES_COMPRESSED; // Size of the compressed ec pubkey of secp256k1.
+
     secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    secp256k1_pubkey pk_list[NR_SIGNERS];    // Signers' public key list
-    secp256k1_pubkey batch_list[NR_SIGNERS * V * NR_MESSAGES];   // Stores the batches of signers
     musig2_context_sig mcs_list[NR_SIGNERS]; // Array that holds NR_SIGNERS musig2_context_sig
-    secp256k1_pubkey deserialized_batch_list[NR_SIGNERS];
-    unsigned char serialized_batch_list[NR_SIGNERS * NR_MESSAGES * ser_size * V];
+    unsigned char serialized_pk_list[NR_SIGNERS * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
+    unsigned char serialized_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];
+    unsigned char serde_batch_list[NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED];    // Signers' public key list
+    secp256k1_pubkey batch_list[NR_SIGNERS * V * NR_MESSAGES];   // Stores the batches of signers
+    secp256k1_pubkey deser_batch_list[NR_SIGNERS * V * NR_MESSAGES];
 
-    int j, k, l, ind;
-    for (i = 0; i < NR_SIGNERS; i++) {
-        if (musig2_init_signer(&mcs_list[i], NR_MESSAGES)) {
-// Store the public key of the signer in pk_list
-            assert (secp256k1_keypair_pub(ctx, &pk_list[i], &mcs_list[i].keypair));
+    err = init_musig2(serialized_pk_list, serialized_batch_list, mcs_list, NR_SIGNERS);
+    ASSERT_EQ(err, 1);
 
-// Store the batch commitments of the signer in batch_list
-            l = 0; // the index of the signer's commitment list.
-            for (k = 0; k < NR_MESSAGES; k++) {
-                for (j = 0; j < V; j++, l++) {
-                    ind = (NR_SIGNERS * V * k) + (j * NR_SIGNERS) + i; // the index for the list of collected batches.
-                    assert(secp256k1_keypair_pub(ctx, &batch_list[ind], mcs_list[i].comm_list[l]));
-// Serialize the commitments and store in serialized_batch_list.
-                    secp256k1_ec_pubkey_serialize(ctx, &serialized_batch_list[ind * ser_size], &ser_size,
-                                                  &batch_list[ind], SECP256K1_EC_COMPRESSED);
-                }
-            }
-        }
-    }
+    for (i = 0; i < NR_SIGNERS * V * NR_MESSAGES; i++)
+        ASSERT_EQ(secp256k1_ec_pubkey_parse(ctx, &deser_batch_list[i], &serialized_batch_list[i * ser_size], ser_size), 1);
 
-    for (i = 0; i < NR_SIGNERS; i++)
-        assert(secp256k1_ec_pubkey_parse(ctx, &deserialized_batch_list[i], &serialized_batch_list[i * ser_size], ser_size));
+    for (i = 0; i < NR_SIGNERS * V * NR_MESSAGES; i++)
+        secp256k1_ec_pubkey_serialize(ctx, &serde_batch_list[i * ser_size], &ser_size, &deser_batch_list[i], SECP256K1_EC_COMPRESSED);
 
-    for (i = 0; i < NR_SIGNERS; i++) {
-        err = secp256k1_ec_pubkey_cmp(ctx, &batch_list[i], &deserialized_batch_list[i]);
-        ASSERT_EQ(err, 0);
-    }
+    for (i = 0; i < NR_MESSAGES * NR_SIGNERS * V * MUSIG2_PUBKEY_BYTES_COMPRESSED; i++)
+        ASSERT_EQ(serde_batch_list[i], serialized_batch_list[i]);
+
 }
 }

--- a/tests/testmusig2.c
+++ b/tests/testmusig2.c
@@ -8,7 +8,7 @@ int init_musig2(secp256k1_context *ctx, unsigned char *serialized_pk_list, unsig
     int ind;
     int err;
     secp256k1_pubkey temp_pk;
-    size_t ser_size = SER_PK_BYTES_COMPRESSED;
+    size_t ser_size = MUSIG2_PUBKEY_BYTES_COMPRESSED;
 
 
     /**** Initialization ****/
@@ -21,7 +21,7 @@ int init_musig2(secp256k1_context *ctx, unsigned char *serialized_pk_list, unsig
 
         /* Store the public key of the signer in pk_list */
         err = secp256k1_keypair_pub(ctx, &temp_pk, &mcs_list[i].keypair);
-        secp256k1_ec_pubkey_serialize(ctx, &serialized_pk_list[i * SER_PK_BYTES_COMPRESSED], &ser_size, &temp_pk, SECP256K1_EC_COMPRESSED);
+        secp256k1_ec_pubkey_serialize(ctx, &serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], &ser_size, &temp_pk, SECP256K1_EC_COMPRESSED);
 
         if (err != 1) {
             return err;
@@ -30,7 +30,7 @@ int init_musig2(secp256k1_context *ctx, unsigned char *serialized_pk_list, unsig
         l = 0; // the index of the signer's commitment list.
         for (k = 0; k < NR_MESSAGES; k++) {
             for (j = 0; j < V; j++, l++) {
-                ind = ((nr_participants * V * k) + (i * V) + j) * SER_PK_BYTES_COMPRESSED; // the index for the list of collected batches.
+                ind = ((nr_participants * V * k) + (i * V) + j) * MUSIG2_PUBKEY_BYTES_COMPRESSED; // the index for the list of collected batches.
                 err = secp256k1_keypair_pub(ctx, &temp_pk, mcs_list[i].comm_list[l]);
                 if (err != 1) {
                     return err;

--- a/tests/testmusig2.c
+++ b/tests/testmusig2.c
@@ -9,15 +9,21 @@ int init_musig2(unsigned char *serialized_pk_list, unsigned char *serialized_bat
 
     /**** Initialization ****/
     for (i = 0; i < nr_participants; i++) {
-        unsigned char serialized_comm_list[V * NR_MESSAGES][MUSIG2_PUBKEY_BYTES_COMPRESSED];
-        unsigned char serialized_pk[MUSIG2_PUBKEY_BYTES_COMPRESSED];
+        err = musig2_init_signer(&mcs_list[i], NR_MESSAGES);
+        if (err != 1)
+            return err;
+    }
 
-        /* Generate a keypair for the signer and get batch commitments. */
-        err = musig2_init_signer(&mcs_list[i], serialized_pk, serialized_comm_list, NR_MESSAGES);
+    /**** Registration ****/
+    for (i = 0; i < nr_participants; i++) {
+        unsigned char serialized_comm_list[V * NR_MESSAGES][MUSIG2_PUBKEY_BYTES_COMPRESSED];
+        unsigned char serialized_pubkey[MUSIG2_PUBKEY_BYTES_COMPRESSED];
+
+        err = musig2_serialise_shareable_context(&mcs_list[i], serialized_pubkey, serialized_comm_list);
         if (err != 1)
             return err;
 
-        memcpy(&serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_pk, MUSIG2_PUBKEY_BYTES_COMPRESSED);
+        memcpy(&serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_pubkey, MUSIG2_PUBKEY_BYTES_COMPRESSED);
         l = 0; // the index of the signer's commitment list.
         for (k = 0; k < NR_MESSAGES; k++)
             for (j = 0; j < V; j++, l++)

--- a/tests/testmusig2.c
+++ b/tests/testmusig2.c
@@ -14,7 +14,7 @@ int init_musig2(secp256k1_context *ctx, unsigned char *serialized_pk_list, unsig
     /**** Initialization ****/
     for (i = 0; i < nr_participants; i++) {
         /* Generate a keypair for the signer and get batch commitments. */
-        err = musig2_init_signer(&mcs_list[i], ctx, NR_MESSAGES);
+        err = musig2_init_signer(&mcs_list[i], NR_MESSAGES);
         if (err != 1) {
             return err;
         }

--- a/tests/testmusig2.c
+++ b/tests/testmusig2.c
@@ -2,42 +2,27 @@
 extern "C" {
 #include "../src/libmusig2.h"
 #include "config.h"
-int init_musig2(secp256k1_context *ctx, unsigned char *serialized_pk_list, unsigned char *serialized_batch_list, musig2_context_sig *mcs_list,
-                int nr_participants) {
-    int i, j, k, l;
-    int ind;
-    int err;
-    secp256k1_pubkey temp_pk;
-    size_t ser_size = MUSIG2_PUBKEY_BYTES_COMPRESSED;
 
+int init_musig2(unsigned char *serialized_pk_list, unsigned char *serialized_batch_list, musig2_context_sig *mcs_list, int nr_participants) {
+    int i, j, k, l;
+    int err;
 
     /**** Initialization ****/
     for (i = 0; i < nr_participants; i++) {
+        unsigned char serialized_comm_list[V * NR_MESSAGES][MUSIG2_PUBKEY_BYTES_COMPRESSED];
+        unsigned char serialized_pk[MUSIG2_PUBKEY_BYTES_COMPRESSED];
+
         /* Generate a keypair for the signer and get batch commitments. */
-        err = musig2_init_signer(&mcs_list[i], NR_MESSAGES);
-        if (err != 1) {
+        err = musig2_init_signer(&mcs_list[i], serialized_pk, serialized_comm_list, NR_MESSAGES);
+        if (err != 1)
             return err;
-        }
 
-        /* Store the public key of the signer in pk_list */
-        err = secp256k1_keypair_pub(ctx, &temp_pk, &mcs_list[i].keypair);
-        secp256k1_ec_pubkey_serialize(ctx, &serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], &ser_size, &temp_pk, SECP256K1_EC_COMPRESSED);
-
-        if (err != 1) {
-            return err;
-        }
-        /* Store the batch commitments of the signer in batch_list */
+        memcpy(&serialized_pk_list[i * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_pk, MUSIG2_PUBKEY_BYTES_COMPRESSED);
         l = 0; // the index of the signer's commitment list.
-        for (k = 0; k < NR_MESSAGES; k++) {
-            for (j = 0; j < V; j++, l++) {
-                ind = ((nr_participants * V * k) + (i * V) + j) * MUSIG2_PUBKEY_BYTES_COMPRESSED; // the index for the list of collected batches.
-                err = secp256k1_keypair_pub(ctx, &temp_pk, mcs_list[i].comm_list[l]);
-                if (err != 1) {
-                    return err;
-                }
-                secp256k1_ec_pubkey_serialize(ctx, &serialized_batch_list[ind], &ser_size, &temp_pk, SECP256K1_EC_COMPRESSED);
-            }
-        }
+        for (k = 0; k < NR_MESSAGES; k++)
+            for (j = 0; j < V; j++, l++)
+                memcpy(&serialized_batch_list[(k * NR_SIGNERS * V + i * V + j) * MUSIG2_PUBKEY_BYTES_COMPRESSED], serialized_comm_list[l],
+                       MUSIG2_PUBKEY_BYTES_COMPRESSED);
     }
     return 1;
 }


### PR DESCRIPTION
This PR  aims to update the library so that the end users do not need to make calls from `secp256k1` as mentioned in #30. The following list provides the changes:


1. Library functions are updated not to take any `secp256k1` parameters, including `secp256k1_context`. Context creation is now handled in library functions.

2. Defined constants renamed, i.e., `SCALAR_BYTES` is changed to `MUSIG2_SCALAR_BYTES`.

3. A new type (`musig2_pubkey`) representing the x_only public key of  `secp256k1` is defined. MuSig2 library does not require full-size public keys; thus,  instead of calling `secp256k1_xonly_pubkey`, users will call `musig2_pubkey`.

4. The function `musig2_prepare_signer_to_register` is created. This function
   - serializes signers' public key and batch commitments in compressed format,
   - called by `musig2_prepare_signer_to_register`,
   - returns `serialized_pk` (33-byte) and `serialized_comm_list`, which is a list of 33-byte commitments with `V * NR_MESSAGES` elements. So, after initialization, these return values can be directly used to register the signer (Collecting public keys and batch commitments.

5. Verification of the final signature with `secp256k1_schnorrsig_verify` is implemented in the library function `musig2_verify_musig2`.

Note that the documentation and comments are not completed yet.

--- 

This closes #30.